### PR TITLE
Mo better errors

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -10,9 +10,9 @@ module OAuth2
 
       message = []
 
-      if response.parsed.is_a?(Hash)
-        @code = response.parsed['error']
-        @description = response.parsed['error_description']
+      set_response_code(response)
+
+      if @code
         message << "#{@code}: #{@description}"
       end
 
@@ -20,5 +20,16 @@ module OAuth2
 
       super(message.join("\n"))
     end
+
+    ## Subclass should override this if repsonse use different keys for error code/description
+    ## E.g. https://github.com/acenqiu/weibo2/blob/master/lib/weibo2/error.rb
+    def set_response_code(response)
+      if response.parsed.is_a?(Hash)
+        @code = response.parsed['error']
+        @description = response.parsed['error_description']
+      end
+    end
+
+
   end
 end


### PR DESCRIPTION
Expand on Pull #89 "Provide more descriptive exception messages" (djanowski). 

https://github.com/intridea/oauth2/pull/89

Move @code and @desription in a separate set_response_code method so it can be overriden by subclass. As other OAuth2 providers may use non-standard key names for errors.

An example for a subclass of OAuth2::Error that needs to change the error @code/@description setters.

Old:
https://github.com/acenqiu/weibo2/blob/master/lib/weibo2/error.rb

New:
https://github.com/goofrider/weibo2/blob/master/lib/weibo2/error.rb
