### PR TITLE
Optionally pass raw response to parsers

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -67,8 +67,13 @@ module OAuth2
     #   Will attempt to parse application/x-www-form-urlencoded and
     #   application/json Content-Type response bodies
     def parsed
-      return nil unless @@parsers.key?(parser)
-      @parsed ||= @@parsers[parser].call(body)
+      defined?(@parsed) ? @parsed : @parsed = begin
+        parser.respond_to?(:call) ? case parser.arity
+          when 0 then parser.call
+          when 1 then parser.call(body)
+          else        parser.call(body, response)
+        end : nil
+      end
     end
 
     # Attempts to determine the content type of the response.
@@ -78,8 +83,8 @@ module OAuth2
 
     # Determines the parser that will be used to supply the content of #parsed
     def parser
-      return options[:parse].to_sym if @@parsers.key?(options[:parse])
-      @@content_types[content_type]
+      parser = options[:parse] && options[:parse].to_sym
+      @parser ||= @@parsers[parser] || @@parsers[@@content_types[content_type]]
     end
   end
 end

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -63,9 +63,10 @@ module OAuth2
       response.body || ''
     end
 
-    # The parsed response body.
-    #   Will attempt to parse application/x-www-form-urlencoded and
-    #   application/json Content-Type response bodies
+    # The {#response} {#body} as parsed by {#parser}.
+    #
+    # @return [Object] As returned by {#parser} if it is #call-able.
+    # @return [nil] If the {#parser} is not #call-able.
     def parsed
       return @parsed if defined?(@parsed)
 
@@ -89,7 +90,22 @@ module OAuth2
       ((response.headers.values_at('content-type', 'Content-Type').compact.first || '').split(';').first || '').strip
     end
 
-    # Determines the parser that will be used to supply the content of #parsed
+    # Determines the parser (a Proc or other Object which responds to #call)
+    # that will be passed the {#body} (and optionall {#response}) to supply
+    # {#parsed}.
+    #
+    # The parser can be supplied as the +:parse+ option in the form of a Proc
+    # (or other Object responding to #call) or a Symbol. In the latter case,
+    # the actual parser will be looked up in {PARSERS} by the supplied Symbol.
+    #
+    # If no +:parse+ option is supplied, the lookup Symbol will be determined
+    # by looking up {#content_type} in {CONTENT_TYPES}.
+    #
+    # If {#parser} is a Proc, it will be called with no arguments, just
+    # {#body}, or {#body} and {#response}, depending on the Proc's arity.
+    #
+    # @return [Proc, #call] If a parser was found.
+    # @return [nil] If no parser was found.
     def parser
       defined?(@parser) ? @parser : @parser = begin
         parser =

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -83,8 +83,15 @@ module OAuth2
 
     # Determines the parser that will be used to supply the content of #parsed
     def parser
-      parser = options[:parse] && options[:parse].to_sym
-      @parser ||= @@parsers[parser] || @@parsers[@@content_types[content_type]]
+      defined?(@parser) ? @parser : @parser = begin
+        parser = if options[:parse].respond_to?(:call)
+          options[:parse]
+        elsif options[:parse]
+          @@parsers[options[:parse].to_sym]
+        end
+
+        parser || @@parsers[@@content_types[content_type]]
+      end
     end
   end
 end

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -105,16 +105,16 @@ module OAuth2
     # @return [Proc, #call] If a parser was found.
     # @return [nil] If no parser was found.
     def parser
-      defined?(@parser) ? @parser : @parser = begin
-        parser =
-          if options[:parse].respond_to?(:call)
-            options[:parse]
-          elsif options[:parse]
-            @@parsers[options[:parse].to_sym]
-          end
+      return @parser if defined?(@parser)
 
-        parser || @@parsers[@@content_types[content_type]]
-      end
+      @parser =
+        if options[:parse].respond_to?(:call)
+          options[:parse]
+        elsif options[:parse]
+          @@parsers[options[:parse].to_sym]
+        end
+
+      @parser ||= @@parsers[@@content_types[content_type]]
     end
   end
 end

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -80,8 +80,6 @@ module OAuth2
           else
             parser.call(body, response)
           end
-        else
-          nil
         end
     end
 

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -74,9 +74,9 @@ describe OAuth2::Response do
       expect(subject.parsed).to be_nil
     end
 
-    it "supports registered parsers with arity == 0; passing nothing" do
+    it 'supports registered parsers with arity == 0; passing nothing' do
       OAuth2::Response.register_parser(:arity_0, []) do
-        "a-ok"
+        'a-ok'
       end
 
       headers   = {'Content-Type' => 'text/html'}
@@ -85,10 +85,10 @@ describe OAuth2::Response do
 
       subject = Response.new(response, :parse => :arity_0)
 
-      expect(subject.parsed).to eq("a-ok")
+      expect(subject.parsed).to eq('a-ok')
     end
 
-    it "supports registered parsers with arity == 2; passing body and response" do
+    it 'supports registered parsers with arity == 2; passing body and response' do
       headers   = {'Content-Type' => 'text/html'}
       body      = '<!DOCTYPE html><html><head></head><body></body></html>'
       response  = double('response', :headers => headers, :body => body)
@@ -97,15 +97,15 @@ describe OAuth2::Response do
         expect(passed_body).to eq(body)
         expect(passed_response).to eq(response)
 
-        "a-ok"
+        'a-ok'
       end
 
       subject = Response.new(response, :parse => :arity_2)
 
-      expect(subject.parsed).to eq("a-ok")
+      expect(subject.parsed).to eq('a-ok')
     end
 
-    it "supports registered parsers with arity > 2; passing body and response" do
+    it 'supports registered parsers with arity > 2; passing body and response' do
       headers   = {'Content-Type' => 'text/html'}
       body      = '<!DOCTYPE html><html><head></head><body></body></html>'
       response  = double('response', :headers => headers, :body => body)
@@ -115,22 +115,22 @@ describe OAuth2::Response do
         expect(passed_response).to eq(response)
         expect(args).to eq([])
 
-        "a-ok"
+        'a-ok'
       end
 
       subject = Response.new(response, :parse => :arity_3)
 
-      expect(subject.parsed).to eq("a-ok")
+      expect(subject.parsed).to eq('a-ok')
     end
 
-    it "supports directly passed parsers" do
+    it 'supports directly passed parsers' do
       headers   = {'Content-Type' => 'text/html'}
       body      = '<!DOCTYPE html><html><head></head><body></body></html>'
       response  = double('response', :headers => headers, :body => body)
 
-      subject = Response.new(response, :parse => lambda { "a-ok" })
+      subject = Response.new(response, :parse => lambda { 'a-ok' })
 
-      expect(subject.parsed).to eq("a-ok")
+      expect(subject.parsed).to eq('a-ok')
     end
   end
 

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -110,10 +110,10 @@ describe OAuth2::Response do
       body      = '<!DOCTYPE html><html><head></head><body></body></html>'
       response  = double('response', :headers => headers, :body => body)
 
-      OAuth2::Response.register_parser(:arity_3, []) do |passed_body, passed_response, empty = nil|
+      OAuth2::Response.register_parser(:arity_3, []) do |passed_body, passed_response, *args|
         expect(passed_body).to eq(body)
         expect(passed_response).to eq(response)
-        expect(empty).to be_nil
+        expect(args).to eq([])
 
         "a-ok"
       end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -122,6 +122,16 @@ describe OAuth2::Response do
 
       expect(subject.parsed).to eq("a-ok")
     end
+
+    it "supports directly passed parsers" do
+      headers   = {'Content-Type' => 'text/html'}
+      body      = '<!DOCTYPE html><html><head></head><body></body></html>'
+      response  = double('response', :headers => headers, :body => body)
+
+      subject = Response.new(response, :parse => lambda { "a-ok" })
+
+      expect(subject.parsed).to eq("a-ok")
+    end
   end
 
   context 'xml parser registration' do

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -73,6 +73,55 @@ describe OAuth2::Response do
       subject = Response.new(response)
       expect(subject.parsed).to be_nil
     end
+
+    it "supports registered parsers with arity == 0; passing nothing" do
+      OAuth2::Response.register_parser(:arity_0, []) do
+        "a-ok"
+      end
+
+      headers   = {'Content-Type' => 'text/html'}
+      body      = '<!DOCTYPE html><html><head></head><body></body></html>'
+      response  = double('response', :headers => headers, :body => body)
+
+      subject = Response.new(response, :parse => :arity_0)
+
+      expect(subject.parsed).to eq("a-ok")
+    end
+
+    it "supports registered parsers with arity == 2; passing body and response" do
+      headers   = {'Content-Type' => 'text/html'}
+      body      = '<!DOCTYPE html><html><head></head><body></body></html>'
+      response  = double('response', :headers => headers, :body => body)
+
+      OAuth2::Response.register_parser(:arity_2, []) do |passed_body, passed_response|
+        expect(passed_body).to eq(body)
+        expect(passed_response).to eq(response)
+
+        "a-ok"
+      end
+
+      subject = Response.new(response, :parse => :arity_2)
+
+      expect(subject.parsed).to eq("a-ok")
+    end
+
+    it "supports registered parsers with arity > 2; passing body and response" do
+      headers   = {'Content-Type' => 'text/html'}
+      body      = '<!DOCTYPE html><html><head></head><body></body></html>'
+      response  = double('response', :headers => headers, :body => body)
+
+      OAuth2::Response.register_parser(:arity_3, []) do |passed_body, passed_response, empty = nil|
+        expect(passed_body).to eq(body)
+        expect(passed_response).to eq(response)
+        expect(empty).to be_nil
+
+        "a-ok"
+      end
+
+      subject = Response.new(response, :parse => :arity_3)
+
+      expect(subject.parsed).to eq("a-ok")
+    end
   end
 
   context 'xml parser registration' do


### PR DESCRIPTION
This addresses the use case described in #156 and should be fully backwards compatible.

Tested against MRI 1.8.7-p374, 1.9.2-p320, 1.9.3-p448, 2.0.0-p247 and jruby-1.7.4.
