### PR TITLE
added support gzip content encoding

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -43,7 +43,7 @@ module OAuth2
 
     # The HTTP response body
     def body
-      response.body || ''
+      @body ||= preprocessing_of_body(response.body)
     end
 
     # Procs that, when called, will parse a response body according
@@ -82,6 +82,19 @@ module OAuth2
       return options[:parse].to_sym if PARSERS.key?(options[:parse])
       CONTENT_TYPES[content_type]
     end
+
+    private
+
+    def content_encoding
+      ((response.headers.values_at('content-encoding', 'Content-Encoding').compact.first || '').split(';').first || '').strip
+    end
+
+    def preprocessing_of_body(resp_body)
+      return '' if resp_body.nil? || resp_body.empty?
+
+      content_encoding == 'gzip' ? Zlib::GzipReader.new(StringIO.new(resp_body)).read : resp_body
+    end
+
   end
 end
 

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -101,7 +101,7 @@ describe OAuth2::Response do
       end
       compressed = str_io.string
     end
-    let(:response) { double('response', status: 200, headers: headers, body: body) }
+    let(:response) { double('response', :status => 200, :headers => headers, :body => body) }
     specify { OAuth2::Response.new(response).parsed.should eq original_data }
   end
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'zlib'
 
 describe OAuth2::Response do
   describe '#initialize' do
@@ -87,5 +88,20 @@ describe OAuth2::Response do
       response = double('response', :headers => headers, :body => body)
       OAuth2::Response.new(response).parsed.should == {"foo" => {"bar" => "baz"}}
     end
+  end
+
+  describe 'when gzip content-encoding' do
+    let(:headers) {{ 'content-type' => 'application/json', 'content-encoding' => 'gzip' }}
+    let(:original_data) {{ 'data' => 'some test data' }}
+    let(:body) do
+      str_io = StringIO.new("w")
+      Zlib::GzipWriter.new(str_io).tap do |gz|
+        gz.write(MultiJson.dump(original_data))
+        gz.close
+      end
+      compressed = str_io.string
+    end
+    let(:response) { double('response', status: 200, headers: headers, body: body) }
+    specify { OAuth2::Response.new(response).parsed.should eq original_data }
   end
 end


### PR DESCRIPTION
I use omniauth-facebook gem. For some users facebook return gzipped body. In this case user can't work on site under fb account.
