### PR TITLE
Put required response_type parameter

### DIFF
--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -26,6 +26,7 @@ module OAuth2
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
         params = {'grant_type' => 'authorization_code', 'code' => code}.merge(client_params).merge(params)
+        params = {'grant_type' => 'authorization_code', 'code' => code, 'response_type' => 'token'}.merge(client_params).merge(params)
         @client.get_token(params, opts)
       end
     end


### PR DESCRIPTION
The required response_type parameter is missing (ref. http://tools.ietf.org/html/rfc6749#section-3.1.1)
