### PR TITLE
Add handler for application/hal+json

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -50,15 +50,12 @@ module OAuth2
     # Procs that, when called, will parse a response body according
     # to the specified format.
     PARSERS = {
-      :json  => lambda { |body| MultiJson.load(body) rescue body }, # rubocop:disable RescueModifier
       :query => lambda { |body| Rack::Utils.parse_query(body) },
       :text  => lambda { |body| body }
     }
 
     # Content type assignments for various potential HTTP content types.
     CONTENT_TYPES = {
-      'application/json' => :json,
-      'text/javascript' => :json,
       'application/x-www-form-urlencoded' => :query,
       'text/plain' => :text
     }
@@ -86,4 +83,8 @@ end
 
 OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml']) do |body|
   MultiXml.parse(body) rescue body # rubocop:disable RescueModifier
+end
+
+OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json']) do |body|
+  MultiJson.load(body) rescue body # rubocop:disable RescueModifier
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -60,6 +60,16 @@ describe OAuth2::Response do
       expect(subject.parsed['answer']).to eq(42)
     end
 
+    it 'parses alternative application/json extension bodies' do
+      headers = {'Content-Type' => 'application/hal+json'}
+      body = MultiJson.encode(:foo => 'bar', :answer => 42)
+      response = double('response', :headers => headers, :body => body)
+      subject = Response.new(response)
+      expect(subject.parsed.keys.size).to eq(2)
+      expect(subject.parsed['foo']).to eq('bar')
+      expect(subject.parsed['answer']).to eq(42)
+    end
+
     it "doesn't try to parse other content-types" do
       headers = {'Content-Type' => 'text/html'}
       body = '<!DOCTYPE html><html><head></head><body></body></html>'


### PR DESCRIPTION
This adds a handler for token server responses of content type `application/hal+json`. I followed the pattern from 56f9758d961fc317a05b2f93fd039588967a84b1 for handling multiple synonymous MIME types. Let me know if this is okay.

I can add in additional JSON extension formats, if you think it makes sense. I omitted Collection+JSON and JSON API because they aren't compatible with the OAuth 2.0 spec.
