### PR TITLE
Update specs to RSpec 2.14.8 syntax

### DIFF
--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -120,8 +120,8 @@ describe OAuth2::Client do
     end
 
     it 'outputs to $stdout when OAUTH_DEBUG=true' do
-      ENV.stub(:[]).with('http_proxy').and_return(nil)
-      ENV.stub(:[]).with('OAUTH_DEBUG').and_return('true')
+      allow(ENV).to receive(:[]).with('http_proxy').and_return(nil)
+      allow(ENV).to receive(:[]).with('OAUTH_DEBUG').and_return('true')
       output = capture_output do
         subject.request(:get, '/success')
       end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 2 conversions
  from: obj.stub(:message)
    to: allow(obj).to receive(:message)
