### PR TITLE
Omit extra params when Authorization header is present

### DIFF
--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -25,7 +25,10 @@ module OAuth2
       # @param [Hash] opts options
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
-        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(client_params).merge(params)
+        headers = params[:headers]
+        has_authorization = headers && !headers['Authorization'].nil?
+        authorization_params = has_authorization ? {} : client_params
+        params = {'grant_type' => 'authorization_code', 'code' => code}.merge(authorization_params).merge(params)
         @client.get_token(params, opts)
       end
     end


### PR DESCRIPTION
The OAuth 2 spec states that a token request with extra parameters or multiple methods of authorizing the client (e.g. both an "Authorization: Basic" header and client_id and client_secret params) should be treated as an invalid_request error.
