### PR TITLE
Adds the :client_auth option

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -33,6 +33,7 @@ module OAuth2
       @options = {:authorize_url    => '/oauth/authorize',
                   :token_url        => '/oauth/token',
                   :token_method     => :post,
+                  :client_auth      => :params,
                   :connection_opts  => {},
                   :connection_build => block,
                   :max_redirects    => 5,

--- a/lib/oauth2/strategy/base.rb
+++ b/lib/oauth2/strategy/base.rb
@@ -9,7 +9,13 @@ module OAuth2
       #
       # @return [Hash]
       def client_params
-        {'client_id' => @client.id, 'client_secret' => @client.secret}
+        case @client.options[:client_auth]
+        when :params
+          {'client_id' => @client.id, 'client_secret' => @client.secret}
+        when :http_basic
+          auth_value = 'Basic ' + Base64.encode64(@client.id + ':' + @client.secret)
+          {:headers => {'Authorization' => auth_value}}
+        end
       end
     end
   end

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -85,4 +85,26 @@ describe OAuth2::Strategy::AuthCode do
       end
     end
   end
+
+  # With the :http_basic client authentication method
+
+  let(:basic_auth) { 'Basic ' + Base64.encode64('abc:def') }
+
+  let(:strict_client) do
+    OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', :client_auth => :http_basic) do |builder|
+      builder.adapter :test do |stub|
+        stub.post('/oauth/token', {'code' => 'sushi', 'grant_type' => 'authorization_code'}, {'Authorization' => basic_auth}) do |env|
+          [200, {'Content-Type' => 'application/json'}, json_token]
+        end
+      end
+    end
+  end
+
+  describe "#get_token with a strict server" do
+    subject { strict_client.auth_code }
+    it 'does not send client_id and client_secret as params' do
+      @access = subject.get_token(code)
+      expect(@access.token).to eq('salmon')
+    end
+  end
 end


### PR DESCRIPTION
This is an alternative to the other pull request that's open which removes extra params when the Authorization header is present.

The solution in this branch requires the user to be explicit and pass the option :client_auth => :http_basic when initializing the client in order to attach HTTP Basic auth to the token request and other requests.
