### PR TITLE
Token is expired if 'expired_at' time is now.

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -70,7 +70,7 @@ module OAuth2
     #
     # @return [Boolean]
     def expired?
-      expires? && (expires_at < Time.now.to_i)
+      expires? && (expires_at <= Time.now.to_i)
     end
 
     # Refreshes the current Access Token

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -133,6 +133,13 @@ describe AccessToken do
       expect(access).to be_expired
     end
 
+    it 'is true if expires_at is now' do
+      @now = Time.now
+      access = AccessToken.new(client, token, :refresh_token => 'abaca', :expires_at => @now.to_i)
+      allow(Time).to receive(:now).and_return(@now)
+      expect(access).to be_expired
+    end
+
   end
 
   describe '#refresh!' do


### PR DESCRIPTION
The `expired?` method on `AccessToken` does not take into account the current time. If `expires_at` is right now `expired?` currently returns `false`. Is there a reason for this?
It means I can not catch a token refresh without using a `rescue` for `OAuth2::Error` after my request then then refreshing the token (which may not always be the cause of the error.

Example code of issue:

``` ruby
require "oauth2"

# Rails app using Doorkeeper with `access_token_expires_in` set to `2.seconds`
client_id = "abc"
client_secret = "def"
endpoint = "https://api.example.com"

client = OAuth2::Client.new(client_id, client_secret, site: endpoint)
token = client.password.get_token("username", "password")
puts token.get("/version").body

# Sleep until the Token is expired
sleep token.expires_at - Time.new.to_i
# Expect this to return true
puts token.expired? # Prints false
token = token.refresh! if token.expired?

# This request fails due to expired Token
puts token.get("/version").body
```
