### PR TITLE
Assertion Strategy should allow any param in claim set

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ end
 
 require 'yardstick/rake/verify'
 Yardstick::Rake::Verify.new do |verify|
-  verify.threshold = 58.8
+  verify.threshold = 58.7
 end
 
 task :default => [:spec, :rubocop, :verify_measurements]

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -83,12 +83,24 @@ module OAuth2
         private_key = params.delete(:private_key)
         # Check required params for signing
         fail(ArgumentError, 'You must provide either :private_key or :hmac_secret value') unless hmac_secret || private_key
+        # If requested validate parameters according to spec
+        validate_required_params!(params) if params.delete(:validate)
         # Encode remaining payload according to given secret
         if hmac_secret
           JWT.encode(params, hmac_secret, 'HS256')
         elsif private_key
           JWT.encode(params, private_key, 'RS256')
         end
+      end
+
+    private
+
+      # Validate required params according to JWT spec
+      # @param [Hash] params claim set to sign
+      # @raise ArgumentError if required values are not present in claim set
+      def validate_required_params!(params)
+        required_keys = [:iss, :sub, :aud, :exp]
+        fail(ArgumentError, "You must provide values for all of #{required_keys}") unless required_keys.all? { |k| params[k] }
       end
     end
   end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -78,6 +78,10 @@ describe OAuth2::Strategy::Assertion do
       expect { subject.build_assertion(claim) }.to raise_error ArgumentError, /:private_key or :hmac_secret/
     end
 
+    it 'raises with :validate => true' do
+      expect { subject.build_assertion(:hmac_secret => secret, :validate => true) }.to raise_error ArgumentError, /You must provide values for all/
+    end
+
   end
 
 end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -53,4 +53,31 @@ describe OAuth2::Strategy::Assertion do
     end
   end
 
+  describe '#build_assertion' do
+
+    # Claim base params
+    let(:claim) do
+      {
+        :iss => 'some issuer',
+        :aud => 'some audience',
+        :prn => 'some principal',
+        :exp => Time.now.utc.to_i + 3600,
+      }
+    end
+
+    let(:secret) { 'secret string' }
+    let(:params) { claim.merge(:hmac_secret => secret) }
+    let(:other_params) { {:iat => Time.now.utc.to_i - 60} }
+
+    it 'builds the assertion with all params but secret' do
+      expect(JWT).to receive(:encode).with(claim, secret, 'HS256')
+      subject.build_assertion(params)
+    end
+
+    it 'raises without :private_key or :hmac_secret' do
+      expect { subject.build_assertion(claim) }.to raise_error ArgumentError, /:private_key or :hmac_secret/
+    end
+
+  end
+
 end


### PR DESCRIPTION
Related to #197, allow any param for `build_assertion` method.

Let me know if this need something else to get merged.
