### PR TITLE
Fixing camel case content types that providers sometimes reply with

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -79,7 +79,7 @@ module OAuth2
     # Determines the parser that will be used to supply the content of #parsed
     def parser
       return options[:parse].to_sym if PARSERS.key?(options[:parse])
-      CONTENT_TYPES[content_type]
+      CONTENT_TYPES[content_type.downcase]
     end
   end
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -60,6 +60,17 @@ describe OAuth2::Response do
       expect(subject.parsed['answer']).to eq(42)
     end
 
+    # Test camelcase content type, happening in some providers
+    it "parses application/Json body" do
+      headers = {'Content-Type' => 'application/Json'}
+      body = MultiJson.encode(:foo => 'bar', :answer => 42)
+      response = double('response', :headers => headers, :body => body)
+      subject = Response.new(response)
+      expect(subject.parsed.keys.size).to eq(2)
+      expect(subject.parsed['foo']).to eq('bar')
+      expect(subject.parsed['answer']).to eq(42)
+    end
+
     it "doesn't try to parse other content-types" do
       headers = {'Content-Type' => 'text/html'}
       body = '<!DOCTYPE html><html><head></head><body></body></html>'
@@ -72,6 +83,16 @@ describe OAuth2::Response do
 
       subject = Response.new(response)
       expect(subject.parsed).to be_nil
+    end
+
+    it "should snakecase json keys when parsing" do
+      headers = {'Content-Type' => 'application/Json'}
+      body = MultiJson.encode("accessToken" => 'bar', "MiGever" => "Ani")
+      response = double('response', :headers => headers, :body => body)
+      subject = Response.new(response)
+      expect(subject.parsed.keys.size).to eq(2)
+      expect(subject.parsed['access_token']).to eq('bar')
+      expect(subject.parsed['mi_gever']).to eq("Ani")
     end
   end
 


### PR DESCRIPTION
Add methods that standardise the response JSON keys into snake cased keys. we tried working with an oauth provider that used the java representation form "accessToken" instead of "access_token".

other thing is that we downcased the content_type header value to match parser matching.
