### PR TITLE
fix for Faraday::RackBuilder::StackLocked when logging debug messages

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -53,6 +53,7 @@ module OAuth2
       @connection ||= begin
         conn = Faraday.new(site, options[:connection_opts])
         conn.build do |b|
+          b.request :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'
           options[:connection_build].call(b)
         end if options[:connection_build]
         conn
@@ -86,8 +87,6 @@ module OAuth2
     # @option opts [Symbol] :parse @see Response::initialize
     # @yield [req] The Faraday request
     def request(verb, url, opts = {}) # rubocop:disable CyclomaticComplexity, MethodLength
-      connection.response :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'
-
       url = connection.build_url(url, opts[:params]).to_s
 
       response = connection.run_request(verb, url, opts[:body], opts[:headers]) do |req|


### PR DESCRIPTION
faraday raises "Faraday::RackBuilder::StackLocked (can't modify middleware stack after making a request)"
if you try to add the logger in the request method.
