### PR TITLE
Adds support for handling respones from Collection+JSON APIs

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -59,6 +59,7 @@ module OAuth2
     CONTENT_TYPES = {
       'application/json' => :json,
       'text/javascript' => :json,
+      'application/vnd.collection+json' => :json,
       'application/x-www-form-urlencoded' => :query,
       'text/plain' => :text,
     }

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -60,6 +60,14 @@ describe OAuth2::Response do
       expect(subject.parsed['answer']).to eq(42)
     end
 
+    it 'parses application/vnd.collection+json body' do
+      headers = {'Content-Type' => 'application/vnd.collection+json'}
+      body = MultiJson.encode(:collection => {})
+      response = double('response', :headers => headers, :body => body)
+      subject = Response.new(response)
+      expect(subject.parsed.keys.size).to eq(1)
+    end
+
     it "doesn't try to parse other content-types" do
       headers = {'Content-Type' => 'text/html'}
       body = '<!DOCTYPE html><html><head></head><body></body></html>'


### PR DESCRIPTION
For APIs using the [Collection+JSON Hypermedia document format](http://amundsen.com/media-types/collection/), responses are not being parsed. Collection+JSON is still JSON, so this PR connects responses with the Collection+JSON content type to the JSON parser.
