### PR TITLE
Request client.get_token does not use headers in methods other then POST

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -127,14 +127,14 @@ module OAuth2
     # @return [AccessToken] the initalized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
+      headers = params.delete(:headers) || {}
       if options[:token_method] == :post
-        headers = params.delete(:headers)
         opts[:body] = params
-        opts[:headers] =  {'Content-Type' => 'application/x-www-form-urlencoded'}
-        opts[:headers].merge!(headers) if headers
+        headers.merge!({'Content-Type' => 'application/x-www-form-urlencoded'})
       else
         opts[:params] = params
       end
+      opts[:headers] = headers unless headers.empty?
       response = request(options[:token_method], token_url, opts)
       error = Error.new(response)
       fail(error) if options[:raise_errors] && !(response.parsed.is_a?(Hash) && response.parsed['access_token'])

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -130,7 +130,7 @@ module OAuth2
       headers = params.delete(:headers) || {}
       if options[:token_method] == :post
         opts[:body] = params
-        headers.merge!({'Content-Type' => 'application/x-www-form-urlencoded'})
+        headers.merge!('Content-Type' => 'application/x-www-form-urlencoded')
       else
         opts[:params] = params
       end


### PR DESCRIPTION
Request does not use headers in methods other then POST. Basic authorization does not work with GET method.
