### PR TITLE
Parse 'application/xml' content type as XML in OAuth2::Response

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -84,6 +84,6 @@ module OAuth2
   end
 end
 
-OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml']) do |body|
+OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml', 'application/xml']) do |body|
   MultiXml.parse(body) rescue body # rubocop:disable RescueModifier
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -87,5 +87,13 @@ describe OAuth2::Response do
       response = double('response', :headers => headers, :body => body)
       expect(OAuth2::Response.new(response).parsed).to eq('foo' => {'bar' => 'baz'})
     end
+
+    it 'is able to parse application/xml' do
+      headers = {'Content-Type' => 'application/xml'}
+      body = '<?xml version="1.0" standalone="yes" ?><foo><bar>baz</bar></foo>'
+
+      response = double('response', :headers => headers, :body => body)
+      expect(OAuth2::Response.new(response).parsed).to eq('foo' => {'bar' => 'baz'})
+    end
   end
 end


### PR DESCRIPTION
I am working with an OAuth2 API that serializes OAuth credentials (`access_token`, `refresh_token`, etc) as XML with the content type`application/xml`.  This content type should be registered to parse as XML by the `OAuth2::Response` class, but is currently absent from the list of content types to be parsed as XML.  This commit simply adds `application/xml` to this list.
