### PR TITLE
Allows passing extra headers to the Client Credentials strategy

### DIFF
--- a/lib/oauth2/strategy/client_credentials.rb
+++ b/lib/oauth2/strategy/client_credentials.rb
@@ -20,7 +20,12 @@ module OAuth2
       def get_token(params = {}, opts = {})
         request_body = opts.delete('auth_scheme') == 'request_body'
         params['grant_type'] = 'client_credentials'
-        params.merge!(request_body ? client_params : {:headers => {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}})
+        if request_body
+          params.merge!(client_params)
+        else
+          authorization_header = {'Authorization' => authorization(client_params['client_id'], client_params['client_secret'])}
+          params[:headers] = (params[:headers] || {}).merge(authorization_header)
+        end
         @client.get_token(params, opts.merge('refresh_token' => nil))
       end
 

--- a/spec/oauth2/strategy/client_credentials_spec.rb
+++ b/spec/oauth2/strategy/client_credentials_spec.rb
@@ -10,6 +10,7 @@ describe OAuth2::Strategy::ClientCredentials do
         stub.post('/oauth/token', 'grant_type' => 'client_credentials') do |env|
           client_id, client_secret = Base64.decode64(env[:request_headers]['Authorization'].split(' ', 2)[1]).split(':', 2)
           client_id == 'abc' && client_secret == 'def' || raise(Faraday::Adapter::Test::Stubs::NotFound)
+          @last_headers = env[:request_headers]
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]
@@ -76,6 +77,17 @@ describe OAuth2::Strategy::ClientCredentials do
           expect(@access.expires_at).not_to be_nil
         end
       end
+    end
+  end
+
+  describe '#get_token (with extra header parameters)' do
+    before do
+      @mode = 'json'
+      @access = subject.get_token(:headers => {'X-Extra-Header' => 'wow'})
+    end
+
+    it 'sends the header correctly.' do
+      expect(@last_headers['X-Extra-Header']).to eq('wow')
     end
   end
 end


### PR DESCRIPTION
Hiya,

This fixes (what I think) is a wee bug with the `client_credentials` grant where it won't allow passing through extra headers to the token request.

It includes a passing spec, although I'll be the first to admit it's a little hacky... any guidance there appreciated.

I also didn't add any documentation since it's a bugfix, and there's language to that effect under [Authorization Grants](https://github.com/intridea/oauth2#authorization-grants) but happy to do that if you'd like.

Cheers!

Nik
