### PR TITLE
Avoid NoMethodError

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -25,7 +25,7 @@ module OAuth2
 
       opts[:error_description] && message << opts[:error_description]
 
-      error_message = if opts[:error_description] && opts[:error_description].respond_to?(:encoding)
+      error_message = if response_body.respond_to?(:encode) && opts[:error_description] && opts[:error_description].respond_to?(:encoding)
                         script_encoding = opts[:error_description].encoding
                         response_body.encode(script_encoding)
                       else


### PR DESCRIPTION
If you use `faraday_middleware` and set `request` to `:json`,
you'll get **"NoMethodError: undefined method `encode' for #Hash:0x007ff31c8487a0"** in https://github.com/intridea/oauth2/blob/fb502c755ed8801aa5d4575f18b86a9b7ecf9f5e/lib/oauth2/error.rb#L28 .

This fixes avoid `NoMethodError` exception.
