### PR TITLE
fix for Doorkeeper incompatibility

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -89,8 +89,14 @@ module OAuth2
       connection.response :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'
 
       url = connection.build_url(url, opts[:params]).to_s
-
-      response = connection.run_request(verb, url, opts[:body], opts[:headers]) do |req|
+      body = nil
+      if opts[:body]
+        opts[:body][:redirect_uri] = opts[:body][:redirect_uri].split("?").first
+        body = URI.encode_www_form(opts[:body])
+      else
+        body = opts
+      end
+      response = connection.run_request(verb, url, body, opts[:headers]) do |req|
         yield(req) if block_given?
       end
       response = Response.new(response, :parse => opts[:parse])

--- a/lib/oauth2/version.rb
+++ b/lib/oauth2/version.rb
@@ -13,7 +13,7 @@ module OAuth2
     #
     # @return [Integer]
     def minor
-      1
+      2
     end
 
     # The patch version


### PR DESCRIPTION
Fixes issue #265 

When secondary authorization request is made to the token url, OAuth2 appends the status code the to redirect URI. This is incompatible with Doorkeeper which then refuses to recognize the registered callback url. I made a minor change to `client.rb` at LOC 92-98--by checking to see if the request being made was the secondary request to the token URL, and changing the redirect URI to remove the appended authorization code and status if so.
