### PR TITLE
Bump rack version in Gemfile to ~> 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :test do
   gem 'backports'
   gem 'coveralls'
   gem 'mime-types', '~> 1.25', :platforms => [:jruby_18, :ruby_18]
-  gem 'rack', '~> 1.2', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
+  gem 'rack', '~> 2.0', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
   gem 'rest-client', '~> 1.6.0', :platforms => [:jruby_18, :ruby_18]
   gem 'rspec', '>= 3'
   gem 'rubocop', '>= 0.37', :platforms => [:ruby_20, :ruby_21]


### PR DESCRIPTION
The version of Rack in the Gemfile is `~> 1.2` whereas in the gemspec it is `[>=1.0, <3]`. For projects relying on this gem but requiring `rack ~> 2.0` bundler fails because it builds agains thte definition in the Gemfile. I have bumped the version so that projects requiring a higher version of rack can still build their bundles  