### PR TITLE
Set the response object on the access token on Client#get_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
-- No significant changes.
+- Set the response object on the access token on Client#get_token (@cpetschnig)
 
 ## [1.3.0] - 2016-12-28
 

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,7 +1,7 @@
 module OAuth2
   class AccessToken
     attr_reader :client, :token, :expires_in, :expires_at, :params
-    attr_accessor :options, :refresh_token
+    attr_accessor :options, :refresh_token, :response
 
     class << self
       # Initializes an AccessToken from a Hash

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -148,7 +148,9 @@ module OAuth2
         error = Error.new(response)
         raise(error)
       end
-      access_token_class.from_hash(self, response.parsed.merge(access_token_opts))
+      access_token_class.from_hash(self, response.parsed.merge(access_token_opts)).tap do |access_token|
+        access_token.response = response if access_token.respond_to?(:response=)
+      end
     end
 
     # The Authorization Code strategy

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -284,6 +284,18 @@ describe OAuth2::Client do
       client.get_token({})
     end
 
+    it 'sets the response object on the access token' do
+      client = stubbed_client do |stub|
+        stub.post('/oauth/token') do
+          [200, {'Content-Type' => 'application/json'}, MultiJson.encode('access_token' => 'the-token')]
+        end
+      end
+
+      token = client.get_token({})
+      expect(token.response).to be_a OAuth2::Response
+      expect(token.response.parsed).to eq('access_token' => 'the-token')
+    end
+
     def stubbed_client(params = {}, &stubs)
       params = {:site => 'https://api.example.com'}.merge(params)
       OAuth2::Client.new('abc', 'def', params) do |builder|


### PR DESCRIPTION
To allow further computation of the actual HTTP call, the response object (`OAuth2::Response`) is stored on the `AccessToken`.

This solves #186.

I hope you are fine with this. I am happy to change the naming/implementation upon your suggestion. Thank you for your great work on this gem!