### PR TITLE
Clarify comment regarding error codes

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -2,8 +2,8 @@ module OAuth2
   class Error < StandardError
     attr_reader :response, :code, :description
 
-    # standard error values include:
-    # :invalid_request, :invalid_client, :invalid_token, :invalid_grant, :unsupported_grant_type, :invalid_scope
+    # standard error codes include:
+    # 'invalid_request', 'invalid_client', 'invalid_token', 'invalid_grant', 'unsupported_grant_type', 'invalid_scope'
     def initialize(response)
       response.error = self
       @response = response


### PR DESCRIPTION
Hey there,

first of all: Thanks for including examples of actual error codes in the comment. This is quite helpful even if you don't have the specification at hand.

However, I was confused for a short moment, since the comment clearly used symbol notation, whereas the
`@code` instance variable is simply filled using the parsed response.