### PR TITLE
Allow new access token class inheriting from AccessToken class to get access token instance of the its own class when refreshed

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -82,7 +82,7 @@ module OAuth2
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh!(params = {}, access_token_opts = {}, access_token_class = self.class)
+    def refresh(params = {}, access_token_opts = {}, access_token_class = self.class)
       raise('A refresh_token is not available') unless refresh_token
       params[:grant_type] = 'refresh_token'
       params[:refresh_token] = refresh_token

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -82,11 +82,11 @@ module OAuth2
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh(params = {})
+    def refresh!(params = {}, access_token_opts = {}, access_token_class = self.class)
       raise('A refresh_token is not available') unless refresh_token
       params[:grant_type] = 'refresh_token'
       params[:refresh_token] = refresh_token
-      new_token = @client.get_token(params)
+      new_token = @client.get_token(params, access_token_opts, access_token_class)
       new_token.options = options
       new_token.refresh_token = refresh_token unless new_token.refresh_token
       new_token

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -194,11 +194,20 @@ RSpec.describe AccessToken do
                                          :expires_in     => 600,
                                          :param_name     => 'o_param')
     end
+    let(:new_access) do
+      NewAccessToken = Class.new(AccessToken)
+      NewAccessToken.new(client, token, :refresh_token  => 'abaca')
+    end
 
     it 'returns a refresh token with appropriate values carried over' do
       refreshed = access.refresh
       expect(access.client).to eq(refreshed.client)
       expect(access.options[:param_name]).to eq(refreshed.options[:param_name])
+    end
+
+    it 'returns a refresh token of the same access token class' do
+      refreshed = new_access.refresh!
+      expect(new_access.class).to eq(refreshed.class)
     end
 
     context 'with a nil refresh_token in the response' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe AccessToken do
                                          :param_name     => 'o_param')
     end
     let(:new_access) do
-      NewAccessToken = Class.new(AccessToken)
+      NewAccessToken = Class.new(described_class)
       NewAccessToken.new(client, token, :refresh_token => 'abaca')
     end
 

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe AccessToken do
     end
     let(:new_access) do
       NewAccessToken = Class.new(AccessToken)
-      NewAccessToken.new(client, token, :refresh_token  => 'abaca')
+      NewAccessToken.new(client, token, :refresh_token => 'abaca')
     end
 
     it 'returns a refresh token with appropriate values carried over' do


### PR DESCRIPTION
When a new class inherits from the AccessToken class, its refresh! method should return an instance of its own class, not of AccessToken's.