### PR TITLE
Fix redirect_uri option : options need to be mutated

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -201,7 +201,7 @@ module OAuth2
     # @return [Hash] the params to add to a request or URL
     def redirection_params
       if options[:redirect_uri]
-        {'redirect_uri' => options[:redirect_uri]}
+        {'redirect_uri' => options.delete(:redirect_uri)}
       else
         {}
       end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -312,4 +312,19 @@ describe OAuth2::Client do
       expect(subject.connection.ssl.fetch(:ca_file)).to eq('foo.pem')
     end
   end
+
+  describe '#redirection_params' do
+    let(:uri) { 'http://test.com' }
+    let(:options) { {:redirect_uri => uri} }
+    subject { OAuth2::Client.new('abc', 'def', options) }
+    it 'mutates options' do
+      expect { subject.redirection_params }.to change { subject.options }
+    end
+
+    it 'remove the redirect_uri key in options' do
+      expect(subject.options).to include(:redirect_uri)
+      subject.redirection_params
+      expect(subject.options).to_not include(:redirect_uri)
+    end
+  end
 end


### PR DESCRIPTION
Without this mutation the finale params look like : 
```ruby
{ ... 'redirect_uri' => 'http...', redirect_uri: 'http...' }
```
And the generated request has two time the param `redirect_uri`, probably not a bug for most servers but when you upgrade oauth2 all your webmocks fail...

For a better fix I think we should remove all mutations on the options attribute, but I don't imagine all side effects.