### PR TITLE
Set basic_auth as default

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -35,7 +35,7 @@ module OAuth2
       @options = {:authorize_url    => '/oauth/authorize',
                   :token_url        => '/oauth/token',
                   :token_method     => :post,
-                  :auth_scheme      => :request_body,
+                  :auth_scheme      => :basic_auth,
                   :connection_opts  => {},
                   :connection_build => block,
                   :max_redirects    => 5,

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -128,7 +128,7 @@ describe OAuth2::Client do
       end
 
       it 'does not add the redirect_uri param to the auth_code token exchange request' do
-        client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+        client = OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
           builder.adapter :test do |stub|
             stub.post('/oauth/token', auth_code_params) do
               [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
@@ -147,7 +147,7 @@ describe OAuth2::Client do
       end
 
       it 'adds the redirect_uri param to the auth_code token exchange request' do
-        client = OAuth2::Client.new('abc', 'def', :redirect_uri => 'https://site.com/oauth/callback', :site => 'https://api.example.com') do |builder|
+        client = OAuth2::Client.new('abc', 'def', :redirect_uri => 'https://site.com/oauth/callback', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
           builder.adapter :test do |stub|
             stub.post('/oauth/token', auth_code_params.merge('redirect_uri' => 'https://site.com/oauth/callback')) do
               [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -58,6 +58,7 @@ describe OAuth2::Strategy::AuthCode do
     before do
       @mode = 'json'
       client.options[:token_method] = :post
+      client.options[:auth_scheme] = :request_body
     end
 
     it 'should not raise an error' do
@@ -77,6 +78,7 @@ describe OAuth2::Strategy::AuthCode do
         before do
           @mode = mode
           client.options[:token_method] = verb
+          client.options[:auth_scheme] = :request_body
           @access = subject.get_token(code)
         end
 


### PR DESCRIPTION
This PR fixes #285 by setting `:basic_auth` as default for `:auth_scheme`