### PR TITLE
Upgrade jwt to 2.0.0

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -6,7 +6,7 @@ require 'oauth2/version'
 
 Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', ['>= 0.8', '< 0.13']
-  spec.add_dependency 'jwt', '~> 1.0'
+  spec.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', ['>= 1.2', '< 3']


### PR DESCRIPTION
Version 2.0.0 of `ruby-jwt` has just been released after being in beta for many months. This PR updates the version used by this gem.