### PR TITLE
Lock Rubocop to 0.50

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'coveralls'
   gem 'rack', '~> 1.2', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
   gem 'rspec', '>= 3'
-  gem 'rubocop', '>= 0.37', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
+  gem 'rubocop', '~> 0.50.0', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
   gem 'simplecov', '>= 0.9'
 
   platforms :jruby_18, :ruby_18 do

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :test do
   gem 'coveralls'
   gem 'rack', '~> 1.2', :platforms => [:jruby_18, :jruby_19, :ruby_18, :ruby_19, :ruby_20, :ruby_21]
   gem 'rspec', '>= 3'
-  gem 'rubocop', '~> 0.50.0', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24]
+  gem 'rubocop', '~> 0.50.0', :platforms => [:ruby_20, :ruby_21, :ruby_22, :ruby_23, :ruby_24] if RUBY_VERSION >= '2.0'
   gem 'simplecov', '>= 0.9'
 
   platforms :jruby_18, :ruby_18 do

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -11,6 +11,7 @@ module OAuth2
     # Procs that, when called, will parse a response body according
     # to the specified format.
     @@parsers = {
+      # rubocop:disable Lint/RescueWithoutErrorClass
       :json  => lambda { |body| MultiJson.load(body) rescue body }, # rubocop:disable RescueModifier
       :query => lambda { |body| Rack::Utils.parse_query(body) },
       :text  => lambda { |body| body },

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -225,7 +225,7 @@ describe OAuth2::Client do
     it 're-encodes response body in the error message' do
       begin
         subject.request(:get, '/ascii_8bit_encoding')
-      rescue => ex
+      rescue OAuth2::Error => ex
         expect(ex.message.encoding.name).to eq('UTF-8')
         expect(ex.message).to eq("invalid_request: é\n{\"error\":\"invalid_request\",\"error_description\":\"��\"}")
       end


### PR DESCRIPTION
Rubocop version updates introduce new rules that can break the build. It's not good to fail a build with unrelated changes because a new version of Rubocop was released. As a solution, lock Rubocop to the latest minor version and fix errors.

This caused build failure in https://github.com/intridea/oauth2/pull/318