### PR TITLE
Support faraday < 0.14

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ begin
   end
 rescue LoadError
   task :rubocop do
-    $stderr.puts 'RuboCop is disabled'
+    warn 'RuboCop is disabled'
   end
 end
 

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -49,7 +49,7 @@ module OAuth2
       @expires_at &&= @expires_at.to_i
       @expires_at ||= Time.now.to_i + @expires_in if @expires_in
       @options = {:mode          => opts.delete(:mode) || :header,
-                  :header_format => opts.delete(:header_format) || 'Bearer %s',
+                  :header_format => opts.delete(:header_format) || 'Bearer %<token>s',
                   :param_name    => opts.delete(:param_name) || 'access_token'}
       @params = opts
     end
@@ -144,7 +144,7 @@ module OAuth2
 
     # Get the headers hash (includes Authorization token)
     def headers
-      {'Authorization' => options[:header_format] % token}
+      {'Authorization' => format(options[:header_format], :token => token)}
     end
 
   private

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.13']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 0.14']
   spec.add_dependency 'jwt', '~> 1.0'
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -225,7 +225,7 @@ describe OAuth2::Client do
     it 're-encodes response body in the error message' do
       begin
         subject.request(:get, '/ascii_8bit_encoding')
-      rescue => ex
+      rescue StandardError => ex
         expect(ex.message.encoding.name).to eq('UTF-8')
         expect(ex.message).to eq("invalid_request: é\n{\"error\":\"invalid_request\",\"error_description\":\"��\"}")
       end


### PR DESCRIPTION
ref #315 and redo #318 

- Update faraday version to `< 0.14`
- Apply `bundle exec rubocop -a`