### PR TITLE
Change how connection is instantiated

### DIFF
--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -44,10 +44,10 @@ describe OAuth2::Client do
     end
 
     it 'is able to pass a block to configure the connection' do
-      connection = double('connection')
       builder = double('builder')
-      allow(connection).to receive(:build).and_yield(builder)
-      allow(Faraday::Connection).to receive(:new).and_return(connection)
+
+      allow(Faraday).to receive(:new).and_yield(builder)
+      allow(builder).to receive(:response)
 
       expect(builder).to receive(:adapter).with(:test)
 


### PR DESCRIPTION
Currently, when running specs there is a warning `WARNING: Unexpected
middleware set after the adapter. This won't be supported from Faraday
1.0.`, if run with `OAUTH_DEBUG=true` then there is the same message
all over specs output, and in addition to that three errors like this

```ruby
  1) OAuth2::Client#request follows redirects properly
     Failure/Error: connection.response :logger, ::Logger.new($stdout) if ENV['OAUTH_DEBUG'] == 'true'

     Faraday::RackBuilder::StackLocked:
       can't modify middleware stack after making a request
     # ./lib/oauth2/client.rb:95:in `request'
     # ./lib/oauth2/client.rb:113:in `request'
     # ./spec/oauth2/client_spec.rb:205:in `block (3 levels) in <top (required)>'
```

This happens because logger for connection is enabled after afapter has
been already set when using `OAUTH_DEBUG=true`.

Fix is to instantiate connection object, set logger and then allow
changing that connection obejct with stuff like adapters.

(cherry picked from commit 432139f04fb9364b4720ce50f5dc3193ffe8e2d5)