### PR TITLE
Rubocop back to '~> 0.50.0'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :test do
   gem 'rack', '~> 1.2' if ruby_version < Gem::Version.new('2.2')
 
   # Rubocop only works on new ruby
-  gem 'rubocop', '>= 0.37' if ruby_version >= Gem::Version.new('2.1')
+  gem 'rubocop', '~> 0.50.0' if ruby_version >= Gem::Version.new('2.1')
 end
 
 gemspec


### PR DESCRIPTION
See: https://github.com/oauth-xx/oauth2/pull/326#discussion_r160230005