### PR TITLE
Lock down RuboCop version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,20 +1,21 @@
 AllCops:
   DisplayCopNames: true # Display the name of the failing cops
+  TargetRubyVersion: 2.1
+
+Metrics/BlockLength:
+  Enabled: false
 
 Metrics/BlockNesting:
   Max: 2
 
 Metrics/LineLength:
-  AllowURI: true
   Enabled: false
 
 Metrics/MethodLength:
-  CountComments: false
   Max: 15
 
 Metrics/ParameterLists:
   Max: 4
-  CountKeywordArgs: true
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
@@ -64,7 +65,4 @@ Style/SymbolArray:
   Enabled: false
 
 Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: 'comma'
-
-Metrics/BlockLength:
-  Enabled: false
+  EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  DisplayCopNames: true # Display the name of the failing cops
+
 Metrics/BlockNesting:
   Max: 2
 

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ group :test do
   gem 'rack', '~> 1.2' if ruby_version < Gem::Version.new('2.2')
 
   # Rubocop only works on new ruby
-  gem 'rubocop', '>= 0.37' if ruby_version >= Gem::Version.new('2.1')
+  gem 'rubocop', '~> 0.52.1' if ruby_version >= Gem::Version.new('2.1')
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -19,9 +19,7 @@ end
 
 begin
   require 'rubocop/rake_task'
-  RuboCop::RakeTask.new do |task|
-    task.options = ['-D'] # Display the name of the failing cops
-  end
+  RuboCop::RakeTask.new
 rescue LoadError
   task :rubocop do
     warn 'RuboCop is disabled'


### PR DESCRIPTION
Locks down RuboCop version to `~> 0.52.1` instead of `>= 0.37`. This should ensure that pull requests don’t run red on Travis whenever RuboCop releases an upgrade.

This PR also trims the .rubocop.yml file a bit. There is no need to specify configuration for a disabled cop, or to specify the same configuration as RuboCop provides by default.

Finally, the `-D` command line flag has been moved into the configuration file as well, as `AllCops[DisplayCopNames] = true`.

cc @pboling 