### PR TITLE
Replace Rack::Utils.escape by CGI.escape

### DIFF
--- a/lib/oauth2.rb
+++ b/lib/oauth2.rb
@@ -1,3 +1,7 @@
+# includes modules from stdlib
+require 'cgi'
+
+# includes gem files
 require 'oauth2/error'
 require 'oauth2/authenticator'
 require 'oauth2/client'

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -48,7 +48,7 @@ describe OAuth2::Strategy::AuthCode do
 
     it 'includes passed in options' do
       cb = 'http://myserver.local/oauth/callback'
-      expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{Rack::Utils.escape(cb)}")
+      expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{CGI.escape(cb)}")
     end
   end
 

--- a/spec/oauth2/strategy/implicit_spec.rb
+++ b/spec/oauth2/strategy/implicit_spec.rb
@@ -16,7 +16,7 @@ describe OAuth2::Strategy::Implicit do
 
     it 'includes passed in options' do
       cb = 'http://myserver.local/oauth/callback'
-      expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{Rack::Utils.escape(cb)}")
+      expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{CGI.escape(cb)}")
     end
   end
 


### PR DESCRIPTION
Fixes the @pboling comment in #332.

> As of [May 2011](https://github.com/rack/rack/pull/140/files#diff-7c1a24d5b2fe58a6f925c7cacc6c55e7) and [continuing to today](https://github.com/jfirebaugh/rack/blob/0700cd04c41cb2e0882521fcf2fdca877b94e0ae/lib/rack/utils.rb#L14) Rack::Utils.escape calls CGI::escape directly, so switching would be fine.
> @pboling https://github.com/oauth-xx/oauth2/issues/332#issuecomment-356140908