### PR TITLE
CI stability and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: bundler
 
 env:
   global:
-    - JRUBY_OPTS="$JRUBY_OPTS --debug"
+    - JRUBY_OPTS="$JRUBY_OPTS -Xcli.debug=true --debug"
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-    - rvm: rbx-2
     - rvm: rbx-3
   fast_finish: true
   include:
@@ -47,7 +46,6 @@ matrix:
       gemfile: gemfiles/jruby-head.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/ruby_head.gemfile
-    - rvm: rbx-2
     - rvm: rbx-3
 
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ before_install:
   - gem update --system
   - gem install bundler
 
-bundler_args: --no-deployment
+bundler_args: --no-deployment --jobs 3 --retry 3
 
 cache: bundler
 
@@ -16,6 +16,8 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
+    - rvm: rbx-2
+    - rvm: rbx-3
   fast_finish: true
   include:
     - rvm: jruby-1.7.27
@@ -45,5 +47,7 @@ matrix:
       gemfile: gemfiles/jruby-head.gemfile
     - rvm: ruby-head
       gemfile: gemfiles/ruby_head.gemfile
+    - rvm: rbx-2
+    - rvm: rbx-3
 
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+- Update testing infrastructure for all supported Rubies (@pboling and @josephpage)
 - **Breaking**: Set `:basic_auth` as default for `:auth_scheme` instead of `:request_body`. This was default behavior before 1.3.0. See [#285](oauth-xx/oauth2#285) (@tetsuya, @wy193777)
 - Token is expired if `expired_at` time is now (@davestevens)
 - Set the response object on the access token on Client#get_token (@cpetschnig)

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,7 @@
 if RUBY_VERSION >= '1.9'
   require 'simplecov'
   require 'coveralls'
+  Coveralls.wear!
 
   SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,14 +1,14 @@
-if RUBY_VERSION >= '1.9'
-  require 'simplecov'
-  require 'coveralls'
-  Coveralls.wear!
+require 'simplecov'
+require 'coveralls'
 
-  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter]
+SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter
+]
 
-  SimpleCov.start do
-    add_filter '/spec'
-    minimum_coverage(95.33)
-  end
+SimpleCov.start do
+  add_filter '/spec'
+  minimum_coverage(95.33)
 end
 
 require 'addressable/uri'


### PR DESCRIPTION
- [x] Add *optional* `rbx-3` build to travis.
- [x] Make Travis builds more stable by adding `--retry 3` for `bundle install`
- [x] Update Coveralls integration with the [recommanded install way](https://docs.travis-ci.com/user/coveralls/)