### PR TITLE
Remove Rdoc or Jeweler related files

### DIFF
--- a/.document
+++ b/.document
@@ -1,5 +1,0 @@
-README.rdoc
-lib/**/*.rb
-bin/*
-features/**/*.feature
-LICENSE

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['michael@intridea.com', 'sferik@gmail.com']
-  spec.files         = %w[.document CONTRIBUTING.md LICENSE.md README.md oauth2.gemspec] + Dir['lib/**/*.rb']
+  spec.files         = %w[CONTRIBUTING.md LICENSE.md README.md oauth2.gemspec] + Dir['lib/**/*.rb']
   spec.homepage      = 'https://github.com/intridea/oauth2'
   spec.licenses      = %w[MIT]
   spec.name          = 'oauth2'


### PR DESCRIPTION
Removes the `.document` files that seems related to Rdoc or Jeweler, but not used. Jeweler is not currently used, and Rdoc has his own `rdoc_files.include` configuration in Rakefile.