### PR TITLE
Ruby 1.9.0 is the minimal supported version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   DisplayCopNames: true # Display the name of the failing cops
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 1.9
 
 Metrics/BlockLength:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   DisplayCopNames: true # Display the name of the failing cops
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.1
+
+Gemspec/RequiredRubyVersion:
+  Enabled: false
 
 Metrics/BlockLength:
   Enabled: false

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.licenses      = %w[MIT]
   spec.name          = 'oauth2'
   spec.require_paths = %w[lib]
+  spec.required_ruby_version = '>= 1.9.0'
   spec.required_rubygems_version = '>= 1.3.5'
   spec.summary       = 'A Ruby wrapper for the OAuth 2.0 protocol.'
   spec.version       = OAuth2::Version


### PR DESCRIPTION
Adds the minimal ruby version (1.9.0) in gemspec
Related to #332 