### PR TITLE
Fall back to default faraday middleware

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -55,7 +55,12 @@ module OAuth2
     def connection
       @connection ||= Faraday.new(site, options[:connection_opts]) do |builder|
         builder.response(:logger, ::Logger.new($stdout)) if ENV['OAUTH_DEBUG'] == 'true'
-        options[:connection_build].call(builder) if options[:connection_build]
+        if options[:connection_build]
+          options[:connection_build].call(builder)
+        else
+          builder.request :url_encoded             # form-encode POST params
+          builder.adapter Faraday.default_adapter  # make requests with Net::HTTP
+        end
       end
     end
 

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -355,4 +355,13 @@ describe OAuth2::Client do
       expect(subject.connection.ssl.fetch(:ca_file)).to eq('foo.pem')
     end
   end
+
+  context 'without a connection-configuration block' do
+    subject do
+      OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com')
+    end
+    fit 'applies default faraday middleware to the connection' do
+      expect(subject.connection.builder.handlers).to eq([Faraday::Request::UrlEncoded, Faraday::Adapter::Test])
+    end
+  end
 end


### PR DESCRIPTION
If you call Faraday.new with a block, Faraday won't default to its default middleware, so we need to manually specify it.
Previously discussed at https://github.com/oauth-xx/oauth2/pull/331