### PR TITLE
JRuby 9K targets Ruby 2.2, and latest version of Rack supports Ruby 2.2

### DIFF
--- a/gemfiles/jruby_9.0.gemfile
+++ b/gemfiles/jruby_9.0.gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem "rack", "~> 1.2"
-
 group :test do
   gem 'rubocop', '~> 0.52.1'
   gem 'rubocop-rspec', '~> 1.22.1'

--- a/gemfiles/jruby_9.1.gemfile
+++ b/gemfiles/jruby_9.1.gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-gem "rack", "~> 1.2"
-
 group :development do
   gem "pry"
 end


### PR DESCRIPTION
No functional changes, just improving the build for JRuby, allowing it to install latest version of rack.

Will merge as soon as it passes the build.