### PR TITLE
OAuth2::AccessToken#refresh! => refresh, with backwards compatibility alias

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -79,7 +79,7 @@ module OAuth2
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh!(params = {})
+    def refresh(params = {})
       raise('A refresh_token is not available') unless refresh_token
       params[:grant_type] = 'refresh_token'
       params[:refresh_token] = refresh_token
@@ -88,6 +88,9 @@ module OAuth2
       new_token.refresh_token = refresh_token unless new_token.refresh_token
       new_token
     end
+    # A compatibility alias
+    # @note does not modify the receiver, so bang is not the default method
+    alias refresh! refresh
 
     # Convert AccessToken to a hash which can be used to rebuild itself with AccessToken.from_hash
     #

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe AccessToken do
     end
   end
 
-  describe '#refresh!' do
+  describe '#refresh' do
     let(:access) do
       described_class.new(client, token, :refresh_token => 'abaca',
                                          :expires_in     => 600,
@@ -161,7 +161,7 @@ RSpec.describe AccessToken do
     end
 
     it 'returns a refresh token with appropriate values carried over' do
-      refreshed = access.refresh!
+      refreshed = access.refresh
       expect(access.client).to eq(refreshed.client)
       expect(access.options[:param_name]).to eq(refreshed.options[:param_name])
     end
@@ -170,7 +170,7 @@ RSpec.describe AccessToken do
       let(:refresh_body) { MultiJson.encode(:access_token => 'refreshed_foo', :expires_in => 600, :refresh_token => nil) }
 
       it 'copies the refresh_token from the original token' do
-        refreshed = access.refresh!
+        refreshed = access.refresh
 
         expect(refreshed.refresh_token).to eq(access.refresh_token)
       end


### PR DESCRIPTION
Closes #169 