### PR TITLE
Stop rescuing parsing failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+- **Breaking**: No longer rescuing errors raised when parsing fails in MultiXml or MultiJson (@pboling)
 - Update testing infrastructure for all supported Rubies (@pboling and @josephpage)
 - **Breaking**: Set `:basic_auth` as default for `:auth_scheme` instead of `:request_body`. This was default behavior before 1.3.0. See [#285](oauth-xx/oauth2#285) (@tetsuya, @wy193777)
 - Token is expired if `expired_at` time is now (@davestevens)

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -117,9 +117,9 @@ module OAuth2
 end
 
 OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml', 'application/xml']) do |body|
-  MultiXml.parse(body) rescue body # rubocop:disable RescueModifier
+  MultiXml.parse(body)
 end
 
 OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json']) do |body|
-  MultiJson.load(body) rescue body # rubocop:disable RescueModifier
+  MultiJson.load(body)
 end


### PR DESCRIPTION
~There weren't even any specs testing that the rescue was happening, so it was never a *real* feature in the first place.~

Oddly, there are tests that are affected, just not in Ruby 2.5.0.  🗡 This will not be easy.

Fixes #167 