### PR TITLE
Fix for OAuth2::Error trying to encode non-encodable objects

### DIFF
--- a/.rubocop_rspec.yml
+++ b/.rubocop_rspec.yml
@@ -21,3 +21,6 @@ RSpec/InstanceVariable:
 
 RSpec/NestedGroups:
   Enabled: false
+  
+RSpec/ExpectInHook:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
     gem 'rubocop-rspec', '~> 1.24.0'
   end
   gem 'pry', '~> 0.11' if ruby_version >= Gem::Version.new('2.0')
+  gem 'rspec-pending_for'
 end
 
 # Specify non-special dependencies in oauth2.gemspec

--- a/gemfiles/jruby_1.7.gemfile
+++ b/gemfiles/jruby_1.7.gemfile
@@ -11,6 +11,7 @@ group :test do
   # gem "rubocop", "~> 0.41.2"
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
 end
 
 gemspec :path => '../'

--- a/gemfiles/jruby_9.0.gemfile
+++ b/gemfiles/jruby_9.0.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/jruby_9.1.gemfile
+++ b/gemfiles/jruby_9.1.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/jruby_head.gemfile
+++ b/gemfiles/jruby_head.gemfile
@@ -9,6 +9,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   # rubocop:disable Bundler/DuplicatedGem
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'

--- a/gemfiles/ruby_1.9.gemfile
+++ b/gemfiles/ruby_1.9.gemfile
@@ -8,6 +8,7 @@ gem 'tins', '< 1.7'
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
 end
 
 gemspec :path => '../'

--- a/gemfiles/ruby_2.0.gemfile
+++ b/gemfiles/ruby_2.0.gemfile
@@ -9,6 +9,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
 end
 
 gemspec :path => '../'

--- a/gemfiles/ruby_2.1.gemfile
+++ b/gemfiles/ruby_2.1.gemfile
@@ -9,6 +9,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/ruby_2.2.gemfile
+++ b/gemfiles/ruby_2.2.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/ruby_2.3.gemfile
+++ b/gemfiles/ruby_2.3.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/ruby_2.4.gemfile
+++ b/gemfiles/ruby_2.4.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/ruby_2.5.gemfile
+++ b/gemfiles/ruby_2.5.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/gemfiles/ruby_head.gemfile
+++ b/gemfiles/ruby_head.gemfile
@@ -7,6 +7,7 @@ end
 group :test do
   gem 'rake'
   gem 'rspec'
+  gem 'rspec-pending_for'
   gem 'rubocop', '~> 0.53.0'
   gem 'rubocop-rspec', '~> 1.24.0'
 end

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -25,7 +25,7 @@ module OAuth2
 
       lines << opts[:error_description] if opts[:error_description]
 
-      error_string = if response_body.respond_to?(:encoding) && opts[:error_description].respond_to?(:encoding)
+      error_string = if response_body.respond_to?(:encode) && opts[:error_description].respond_to?(:encoding)
                        script_encoding = opts[:error_description].encoding
                        response_body.encode(script_encoding, :invalid => :replace, :undef => :replace)
                      else

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -7,11 +7,13 @@ module OAuth2
     def initialize(response)
       response.error = self
       @response = response
+      error_description = ''
 
       if response.parsed.is_a?(Hash)
         @code = response.parsed['error']
         @description = response.parsed['error_description']
-        error_description = "#{@code}: #{@description}"
+        error_description << "#{@code}: " if @code
+        error_description << @description if @description
       end
 
       super(error_message(response.body, :error_description => error_description))
@@ -23,7 +25,7 @@ module OAuth2
     def error_message(response_body, opts = {})
       message = []
 
-      opts[:error_description] && message << opts[:error_description]
+      message << opts[:error_description] unless opts[:error_description].empty?
 
       error_message = if opts[:error_description] && opts[:error_description].respond_to?(:encoding)
                         script_encoding = opts[:error_description].encoding

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe OAuth2::Error do
+  let(:subject) { described_class.new(response) }
+  let(:response) do
+    fake_response = double(
+      'response', 
+      :status  => 418,
+      :headers => response_headers,
+      :body    => response_body,
+    )
+    
+    OAuth2::Response.new(fake_response)
+  end
+
+  let(:response_headers) { {'Content-Type' => 'application/json'} }
+  let(:response_body) { {:text => 'Coffee brewing failed'}.to_json }
+
+  it 'sets self to #error on the response object' do
+    expect(response.error).to be_nil
+    error = described_class.new(response)
+    expect(response.error).to equal(error)
+  end
+  
+  it 'sets the response object to #response on self' do
+    error = described_class.new(response)
+    expect(error.response).to equal(response)
+  end
+  
+  describe 'attr_readers' do
+    it 'has code' do
+      expect(subject).to respond_to(:code)
+    end
+    
+    it 'has description' do
+      expect(subject).to respond_to(:description)
+    end
+    
+    it 'has response' do
+      expect(subject).to respond_to(:response)
+    end
+  end
+
+  context 'when the response is parseable as a hash' do
+    let(:response_body) { response_hash.to_json }
+    let(:response_hash) { {:text => 'Coffee brewing failed'} }
+
+    context 'when the response has an error and error_description' do
+      before do
+        response_hash[:error_description] = 'Short and stout'
+        response_hash[:error] = 'i_am_a_teapot'
+      end
+
+      it 'prepends to the error message with a return character' do
+        expect(subject.message.lines).to eq([
+          'i_am_a_teapot: Short and stout' + "\n",
+          '{"text":"Coffee brewing failed","error_description":"Short and stout","error":"i_am_a_teapot"}'
+        ])
+      end
+
+      it 'sets the code attribute' do
+        expect(subject.code).to eq('i_am_a_teapot')
+      end
+
+      it 'sets the description attribute' do
+        expect(subject.description).to eq('Short and stout')
+      end
+    end
+
+    context 'when there is no error description' do
+      before do
+        expect(response_hash).to_not have_key(:error)
+        expect(response_hash).to_not have_key(:error_description)
+      end
+
+      it 'does not prepend anything to the message' do
+        expect(subject.message.lines.count).to eq(1)
+        expect(subject.message).to eq '{"text":"Coffee brewing failed"}'
+      end
+
+      it 'does not set code' do
+        expect(subject.code).to be_nil
+      end
+
+      it 'does not set description' do
+        expect(subject.description).to be_nil
+      end
+    end
+  end
+
+  context 'when the response does not parse to a hash' do
+    let(:response_headers) { {'Content-Type' => 'text/html'} }
+    let(:response_body) { '<!DOCTYPE html><html><head>Hello, I am a teapot</head><body></body></html>' }
+
+    it 'does not do anything to the message' do
+      expect(subject.message.lines.count).to eq(1)
+      expect(subject.message).to eq(response_body)
+    end
+    
+    it 'does not set code' do
+      expect(subject.code).to be_nil
+    end
+    
+    it 'does not set description' do
+      expect(subject.description).to be_nil
+    end
+  end
+end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -63,12 +63,12 @@ RSpec.describe OAuth2::Error do
 
         context 'with invalid characters present' do
           before do
-            response_body.gsub!('failed', "\255 invalid \255")
+            response_body.gsub!('stout', "\255 invalid \255")
           end
 
           it 'replaces them' do
-            expect(subject.message).to match(/� invalid �/)
-            # This will fail with Encoding::InvalidByteSequenceError if {:invalid => replace} is not passed in
+            expect(subject.message.include?("� invalid �")).to be_truthy
+            # This will fail if {:invalid => replace} is not passed into `encode`
           end
         end
 
@@ -78,8 +78,8 @@ RSpec.describe OAuth2::Error do
           end
 
           it 'replaces them' do
-            expect(subject.message).to match(/tea �/)
-            # This will fail with Encoding::CompatibilityError if {:undef => replace} is not passed in
+            expect(subject.message.include?("tea �")).to be_truthy
+            # This will fail if {:undef => replace} is not passed into `encode`
           end
         end
       end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 RSpec.describe OAuth2::Error do
   let(:subject) { described_class.new(response) }
   let(:response) do
@@ -68,9 +69,9 @@ RSpec.describe OAuth2::Error do
 
           it 'replaces them' do
             # The skip can be removed once support for < 2.1 is dropped.
-            encoding_skip = {:versions => %w[1.8.7 1.9.3 2.0.0], :reason => 'encode/scrub only works as of Ruby 2.1'}
-            skip_for(encoding_skip.merge(:engine => 'ruby'))
-            skip_for(encoding_skip.merge(:engine => 'jruby'))
+            encoding = {:reason => 'encode/scrub only works as of Ruby 2.1'}
+            skip_for(encoding.merge(:engine => 'ruby', :versions => %w[1.8.7 1.9.3 2.0.0]))
+            skip_for(encoding.merge(:engine => 'jruby'))
             # See https://bibwild.wordpress.com/2013/03/12/removing-illegal-bytes-for-encoding-in-ruby-1-9-strings/
 
             raise 'Invalid characters not replaced' unless subject.message.include?('� invalid �')

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe OAuth2::Error do
           end
 
           it 'replaces them' do
+            # The skip can be removed once support for < 2.1 is dropped.
+            encoding_skip = {:versions => %w[1.8.7 1.9.3 2.0.0], :reason => 'encode/scrub only works as of Ruby 2.1'}
+            skip_for(encoding_skip.merge(:engine => 'ruby'))
+            skip_for(encoding_skip.merge(:engine => 'jruby'))
+            # See https://bibwild.wordpress.com/2013/03/12/removing-illegal-bytes-for-encoding-in-ruby-1-9-strings/
+
             raise 'Invalid characters not replaced' unless subject.message.include?('� invalid �')
             # This will fail if {:invalid => replace} is not passed into `encode`
           end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe OAuth2::Error do
           end
 
           it 'replaces them' do
-            expect(subject.message.include?("� invalid �")).to be_truthy
+            raise 'Invalid characters not replaced' unless subject.message.include?('� invalid �')
             # This will fail if {:invalid => replace} is not passed into `encode`
           end
         end
@@ -78,7 +78,7 @@ RSpec.describe OAuth2::Error do
           end
 
           it 'replaces them' do
-            expect(subject.message.include?("tea �")).to be_truthy
+            raise 'Undefined characters not replaced' unless subject.message.include?('tea �')
             # This will fail if {:undef => replace} is not passed into `encode`
           end
         end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -71,6 +71,20 @@ RSpec.describe OAuth2::Error do
         end
       end
 
+      context 'when the response is not an encodable thing' do
+        let(:response_headers) { {'Content-Type' => 'who knows'} }
+        let(:response_body) { {:text => 'Coffee brewing failed'} }
+
+        before do
+          expect(response_body).not_to respond_to(:encode)
+          # i.e. a Ruby hash
+        end
+
+        it 'does not try to encode the message string' do
+          expect(subject.message).to eq(response_body.to_s)
+        end
+      end
+
       it 'sets the code attribute' do
         expect(subject.code).to eq('i_am_a_teapot')
       end
@@ -104,6 +118,10 @@ RSpec.describe OAuth2::Error do
   context 'when the response does not parse to a hash' do
     let(:response_headers) { {'Content-Type' => 'text/html'} }
     let(:response_body) { '<!DOCTYPE html><html><head>Hello, I am a teapot</head><body></body></html>' }
+    
+    before do
+      expect(response.parsed).not_to be_a(Hash)
+    end
 
     it 'does not do anything to the message' do
       expect(subject.message.lines.count).to eq(1)
@@ -116,19 +134,6 @@ RSpec.describe OAuth2::Error do
 
     it 'does not set description' do
       expect(subject.description).to be_nil
-    end
-  end
-
-  describe 'message body encoding' do
-    context 'when the response is not an encodable thing' do
-      # i.e. a Ruby hash
-
-      let(:response_headers) { {'Content-Type' => 'who knows'} }
-      let(:response_body) { {:text => 'Coffee brewing failed'} }
-
-      it 'does not try to encode the message string' do
-        expect(subject.message).to eq(response_body.to_s)
-      end
     end
   end
 end

--- a/spec/oauth2/error_spec.rb
+++ b/spec/oauth2/error_spec.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+
 RSpec.describe OAuth2::Error do
   let(:subject) { described_class.new(response) }
   let(:response) do
@@ -51,7 +52,7 @@ RSpec.describe OAuth2::Error do
       end
 
       it 'prepends to the error message with a return character' do
-        expect(subject.message.lines).to eq(
+        expect(subject.message.each_line.to_a).to eq(
           [
             'i_am_a_teapot: Short and stout' + "\n",
             '{"text":"Coffee brewing failed","error_description":"Short and stout","error":"i_am_a_teapot"}',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'bundler/setup'
 require 'oauth2'
 require 'helper'
+require 'rspec/pending_for'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
We are pretty interested in seeing `2.0.0` released so we can unfork ourselves -- I was looking down the list of remaining items in https://github.com/oauth-xx/oauth2/milestone/1 and thought I might try to pitch in.

This is a replacement for https://github.com/oauth-xx/oauth2/pull/261 which looks dead.  The issue is trying to call `encode` on something which does not have an `encode` method.  However in trying to test (drive!) a fix for it, it seemed like there were no tests present at all for the `OAuth2::Error` class.  I created a new spec file and did my best to backfill specs for the already-existing functionality (of which there is quite a bit tacked on to the inherited `StandardError` behavior).

The GitHub diff of the error class itself looks kind of weird because of indentation, but a brief rundown of changes:
 - Made `#error_message` private.  Nothing outside this file talks to this method, and it sure seems like a "generate a formatted string for the error message" internal thing.
 - Renamed some locals to make me less nervous (e.g. `error_message` inside of `def error_message`, `message` inside a class descending from `StandardError`).
 - Made `#initialize` not rely on a local being defined only inside an `if` branch.  (Haha I know it works because Ruby is maaaagic, but y'know)
 - If `error_description` is present but not `error`, avoid displaying an errant `": "`.
 - If a formatted error description is not nil but is blank, avoid displaying a blank newline.
 - Backfilled specs for encoding and multi-line message generation.

Also: I was unable to determine why `@code` and `@description` are set and made into `attr_reader`s -- nothing outside the file seems to talk to those things either.  However, folks using this error in their implementations certainly could be relying on being able to call `error.code` or whatever.  I elected to leave them there (and _test_ that they are there), but open to suggestions on that front.