### PR TITLE
Bumps Faraday to < 0.16.0, recover spec

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 0.15.0']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 0.16.0']
   spec.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe OAuth2::Client do
           subject.request(:get, '/success')
         end
 
-        expect(output).to include 'INFO -- : get https://api.example.com/success', 'INFO -- : get https://api.example.com/success'
+        expect(output).to include 'INFO -- request: GET https://api.example.com/success'
       end
     end
 


### PR DESCRIPTION
Per the discussion here https://github.com/oauth-xx/oauth2/issues/373#issuecomment-380650988

It appears to be a simple spec recovery after reviewing the diff here https://github.com/lostisland/faraday/compare/v0.14.0...v0.15.0#diff-edec4a38ac976ddeb50ec36ed13bf8e1R23

closes #384 