### PR TITLE
Take time skew into consideration

### DIFF
--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -151,6 +151,30 @@ RSpec.describe AccessToken do
       allow(Time).to receive(:now).and_return(@now)
       expect(access).to be_expired
     end
+
+    describe 'time skew' do
+      let(:time_skew) { 10 }
+      let(:expires_in) { 300 }
+      let(:expires_at) { Time.now.to_i - 10 + expires_in }
+      let!(:access) { described_class.new(client, token, :refresh_token => 'abaca', :expires_at => expires_at, :expires_in => expires_in) }
+
+      context 'when not within time skew correction' do
+        let(:now) { Time.at(expires_at) + time_skew + 1 }
+
+        it 'access is expired' do
+          allow(Time).to receive(:now).and_return(now)
+          expect(access).to be_expired
+        end
+      end
+
+      context 'when within time skew correction' do
+        let(:now) { Time.at(expires_at) + time_skew - 1 }
+
+        it 'access is not expired' do
+          expect(access).to_not be_expired
+        end
+      end
+    end
   end
 
   describe '#refresh' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe AccessToken do
         let(:now) { Time.at(expires_at) + time_skew - 1 }
 
         it 'access is not expired' do
-          expect(access).to_not be_expired
+          expect(access).not_to be_expired
         end
       end
     end


### PR DESCRIPTION
We have seen instances where `expired?` returns false but it actually is expired, and we think it might be due to time skew.

So, when checking if a token is expired, we should try to take time skew into consideration.

Ideally I would have had `issued_at` as part of the hash, since it should be read from the server. But for now I decided to calculate it (calculated_issued_at), I think it might be good enough.

