### PR TITLE
Take clock skew and min validity into consideration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,3 +13,9 @@ Style/EachWithObject:
 # Once we drop Rubies that lack support for __dir__ we can turn this on.
 Style/ExpandPathArguments:
   Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Max: 7
+
+Metrics/ClassLength:
+  Max: 103

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,8 +14,5 @@ Style/EachWithObject:
 Style/ExpandPathArguments:
   Enabled: false
 
-Metrics/CyclomaticComplexity:
-  Max: 7
-
 Metrics/ClassLength:
-  Max: 104
+  Max: 105

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,4 +18,4 @@ Metrics/CyclomaticComplexity:
   Max: 7
 
 Metrics/ClassLength:
-  Max: 103
+  Max: 104

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fix logging to `$stdout` of request and response bodies via Faraday's logger and `ENV["OAUTH_DEBUG"] == 'true'`
 - Read issued_at and expires_at from the token instead of using Time.now [#391]
 - Take clock skew into consideration when checking expired? [#391]
+- Take minimum validity into consideration when checking expired? [#391]
 
 ## [1.4.0] - 2017-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Change Log
+
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
@@ -12,6 +13,8 @@ All notable changes to this project will be documented in this file.
 - _Dependency_: Upgrade Faraday to 0.13.x (@zacharywelch)
 - _Dependency_: Upgrade jwt to 2.x.x (@travisofthenorth)
 - Fix logging to `$stdout` of request and response bodies via Faraday's logger and `ENV["OAUTH_DEBUG"] == 'true'`
+- Read issued_at and expires_at from the token instead of using Time.now [#391]
+- Take clock skew into consideration when checking expired? [#391]
 
 ## [1.4.0] - 2017-06-09
 
@@ -49,14 +52,17 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0] - 2014-07-09
 
 ### Added
+
 - Add an implementation of the MAC token spec.
 
 ### Fixed
+
 - Fix Base64.strict_encode64 incompatibility with Ruby 1.8.7.
 
 ## [0.5.0] - 2011-07-29
 
 ### Changed
+
 - [breaking] `oauth_token` renamed to `oauth_bearer`.
 - [breaking] `authorize_path` Client option renamed to `authorize_url`.
 - [breaking] `access_token_path` Client option renamed to `token_url`.
@@ -88,7 +94,6 @@ All notable changes to this project will be documented in this file.
 ## [0.0.5] - 2010-04-23
 
 ## [0.0.4] + [0.0.3] + [0.0.2] + [0.0.1] - 2010-04-22
-
 
 [0.0.1]: https://github.com/oauth-xx/oauth2/compare/311d9f4...v0.0.1
 [0.0.2]: https://github.com/oauth-xx/oauth2/compare/v0.0.1...v0.0.2

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,6 +1,6 @@
 module OAuth2
   class AccessToken
-    attr_reader :client, :token, :expires_in, :expires_at, :params, :token_payload, :time_skew
+    attr_reader :client, :token, :expires_in, :expires_at, :params, :time_skew
     attr_accessor :options, :refresh_token, :response
 
     class << self

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,5 +1,7 @@
 module OAuth2
   class AccessToken
+    MIN_VALIDITY = 30
+
     attr_reader :client, :token, :expires_in, :issued_at, :expires_at, :params, :time_skew
     attr_accessor :options, :refresh_token, :response
 
@@ -81,7 +83,7 @@ module OAuth2
     #
     # @return [Boolean]
     def expired?
-      expires? && (expires_at + time_skew <= Time.now.to_i)
+      expires? && (expires_at + time_skew - MIN_VALIDITY <= Time.now.to_i)
     end
 
     # Refreshes the current Access Token

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -172,7 +172,7 @@ module OAuth2
     #
     # @return [Hash] a hash of token property values
     def token_payload
-      @token_payload ||= decoded_token(:payload)
+      @token_payload ||= decoded_payload
     end
 
     # A JWT token consists of three dot separated parts:
@@ -180,23 +180,11 @@ module OAuth2
     #   2) payload
     #   3) verify_signature
     #
-    # Some access tokens are not JWT tokens,
-    #   in which case nil is returned
-    def decoded_token(part)
-      token_chunks = token.split('.')
-      selected_chunk = case part
-      when :header
-        token_chunks.fetch(0)
-      when :payload
-        token_chunks.fetch(1)
-      when :verify_signature
-        token_chunks.fetch(2)
-      else
-        raise(ArgumentError, "#{part} is not a valid token chunk, valid arguments: [:header, :payload, :verify_signature]")
-      end
-
-      JSON Base64.decode64(selected_chunk)
-    rescue
+    # @return [Hash] a hash of token property values
+    def decoded_payload
+      jwt_payload = token.split('.').fetch(1)
+      JSON Base64.decode64(jwt_payload)
+    rescue StandardError
       {}
     end
 

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -37,7 +37,7 @@ module OAuth2
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
     # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
-    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize
+    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       local_now = Time.now.to_i
       @client = client
       @token = token.to_s
@@ -168,7 +168,6 @@ module OAuth2
     #   "azp": "client-identifier"
     # }
     #
-    # For non-JWT tokens, an empty Hash is stored
     #
     # @return [Hash] a hash of token property values
     def token_payload
@@ -179,6 +178,8 @@ module OAuth2
     #   1) header
     #   2) payload
     #   3) verify_signature
+    #
+    # For non-JWT tokens, an empty Hash is returned
     #
     # @return [Hash] a hash of token property values
     def decoded_payload

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -86,7 +86,7 @@ module OAuth2
     end
 
     # Determines the parser (a Proc or other Object which responds to #call)
-    # that will be passed the {#body} (and optionall {#response}) to supply
+    # that will be passed the {#body} (and optional {#response}) to supply
     # {#parsed}.
     #
     # The parser can be supplied as the +:parse+ option in the form of a Proc

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe AccessToken do
         'aud' => 'client-identifier',
         'sub' => 'subject-identifier',
         'typ' => 'Bearer',
-        'azp' => 'client-identifier'
+        'azp' => 'client-identifier',
       }
     end
     let(:token) { @token ||= JWT.encode(token_payload, rsa_private, 'RS256') }
@@ -235,7 +235,7 @@ RSpec.describe AccessToken do
         'aud' => 'client-identifier',
         'sub' => 'subject-identifier',
         'typ' => 'Bearer',
-        'azp' => 'client-identifier'
+        'azp' => 'client-identifier',
       }
     end
     let(:refresh_token) { @refresh_token ||= JWT.encode(refresh_token_payload, rsa_private, 'RS256') }

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -151,6 +151,30 @@ RSpec.describe AccessToken do
       allow(Time).to receive(:now).and_return(@now)
       expect(access).to be_expired
     end
+
+    describe 'time skew' do
+      let(:time_skew) { 10 }
+      let(:expires_in) { 300 }
+      let(:expires_at) { Time.now.to_i - 10 + expires_in }
+      let!(:access) { described_class.new(client, token, :refresh_token => 'abaca', :expires_at => expires_at, :expires_in => expires_in) }
+
+      context 'when not within time skew correction' do
+        let(:now) { Time.at(expires_at) + time_skew + 1 }
+
+        it 'access is expired' do
+          allow(Time).to receive(:now).and_return(now)
+          expect(access).to be_expired
+        end
+      end
+
+      context 'when within time skew correction' do
+        let(:now) { Time.at(expires_at) + time_skew - 1 }
+
+        it 'access is not expired' do
+          expect(access).to_not be_expired
+        end
+      end
+    end
   end
 
   describe '#refresh' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe AccessToken do
         let(:now) { Time.at(expires_at) + time_skew - 1 }
 
         it 'access is not expired' do
-          expect(access).to_not be_expired
+          expect(access).not_to be_expired
         end
       end
     end
@@ -214,32 +214,28 @@ RSpec.describe AccessToken do
     let(:rsa_public) { rsa_private.public_key }
     let(:token_payload) do
       Hash(
-        {
-          "exp": exp,
-          "nbf": 0,
-          "iat": now.to_i,
-          "iss": "https://example.com/auth/realms/issuer",
-          "aud": "client-identifier",
-          "sub": "subject-identifier",
-          "typ": "Bearer",
-          "azp": "client-identifier"
-        }
+        'exp' => exp,
+        'nbf' => 0,
+        'iat' => now.to_i,
+        'iss' => 'https://example.com/auth/realms/issuer',
+        'aud' => 'client-identifier',
+        'sub' => 'subject-identifier',
+        'typ' => 'Bearer',
+        'azp' => 'client-identifier'
       )
     end
     let(:token) { @token ||= JWT.encode(token_payload, rsa_private, 'RS256') }
 
     let(:refresh_token_payload) do
       Hash(
-        {
-          "exp": exp_refresh,
-          "nbf": 0,
-          "iat": refreshed_now.to_i,
-          "iss": "https://example.com/auth/realms/issuer",
-          "aud": "client-identifier",
-          "sub": "subject-identifier",
-          "typ": "Bearer",
-          "azp": "client-identifier"
-        }
+        'exp' => exp_refresh,
+        'nbf' => 0,
+        'iat' => refreshed_now.to_i,
+        'iss' => 'https://example.com/auth/realms/issuer',
+        'aud' => 'client-identifier',
+        'sub' => 'subject-identifier',
+        'typ' => 'Bearer',
+        'azp' => 'client-identifier'
       )
     end
     let(:refresh_token) { @refresh_token ||= JWT.encode(refresh_token_payload, rsa_private, 'RS256') }
@@ -273,7 +269,7 @@ RSpec.describe AccessToken do
 
         it 'access is not expired' do
           allow(Time).to receive(:now).and_return(local_now)
-          expect(access).to_not be_expired
+          expect(access).not_to be_expired
         end
       end
     end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe AccessToken do
     let(:rsa_private) { OpenSSL::PKey::RSA.generate 2048 }
     let(:rsa_public) { rsa_private.public_key }
     let(:token_payload) do
-      Hash(
+      {
         'exp' => exp,
         'nbf' => 0,
         'iat' => now.to_i,
@@ -222,12 +222,12 @@ RSpec.describe AccessToken do
         'sub' => 'subject-identifier',
         'typ' => 'Bearer',
         'azp' => 'client-identifier'
-      )
+      }
     end
     let(:token) { @token ||= JWT.encode(token_payload, rsa_private, 'RS256') }
 
     let(:refresh_token_payload) do
-      Hash(
+      {
         'exp' => exp_refresh,
         'nbf' => 0,
         'iat' => refreshed_now.to_i,
@@ -236,7 +236,7 @@ RSpec.describe AccessToken do
         'sub' => 'subject-identifier',
         'typ' => 'Bearer',
         'azp' => 'client-identifier'
-      )
+      }
     end
     let(:refresh_token) { @refresh_token ||= JWT.encode(refresh_token_payload, rsa_private, 'RS256') }
 


### PR DESCRIPTION
Real implementation of #390 (clock skew)

Changes
- Read issued at from the actual token instead of using Time.now (client time)
- Read expires_at from the actual token instead of using Time.now (client time) and adding expires_in to it
- Take clock skew into consideration when checking if token is expired

In case the token is not a JWT token with the expected keys, the old functionality is intact (use Time.now)

Thanks to @ashaeron for helping me :)