### PR TITLE
Expire the token prematurely on client side

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -38,19 +38,21 @@ module OAuth2
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
     # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
-    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity
       @client = client
       @token = token.to_s
       opts = opts.dup
       [:refresh_token, :expires_in, :expires_at, :expires_latency].each do |arg|
         instance_variable_set("@#{arg}", opts.delete(arg) || opts.delete(arg.to_s))
       end
-      @expires_latency ||= 0
       @expires_in ||= opts.delete('expires')
       @expires_in &&= @expires_in.to_i
       @expires_at &&= @expires_at.to_i
       @expires_latency &&= @expires_latency.to_i
-      @expires_at ||= Time.now.to_i + @expires_in - @expires_latency if @expires_in
+      if @expires_in
+        @expires_at ||= Time.now.to_i + @expires_in
+        @expires_at -= @expires_latency if @expires_latency
+      end
       @options = {:mode          => opts.delete(:mode) || :header,
                   :header_format => opts.delete(:header_format) || 'Bearer %s',
                   :param_name    => opts.delete(:param_name) || 'access_token'}

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,5 +1,6 @@
 module OAuth2
   class AccessToken
+    REDUCE_VALIDITY = 10
     attr_reader :client, :token, :expires_in, :expires_at, :params
     attr_accessor :options, :refresh_token, :response
 
@@ -69,10 +70,12 @@ module OAuth2
     end
 
     # Whether or not the token is expired
+    # - The client will expire the token REDUCE_VALIDITY seconds
+    #   prematurely to offset latency issues
     #
     # @return [Boolean]
     def expired?
-      expires? && (expires_at <= Time.now.to_i)
+      expires? && (expires_at - REDUCE_VALIDITY <= Time.now.to_i)
     end
 
     # Refreshes the current Access Token

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -38,7 +38,7 @@ module OAuth2
     # @option opts [String] :header_format ('Bearer %s') the string format to use for the Authorization header
     # @option opts [String] :param_name ('access_token') the parameter name to use for transmission of the
     #    Access Token value in :body or :query transmission mode
-    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize
+    def initialize(client, token, opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       @client = client
       @token = token.to_s
       opts = opts.dup

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -49,10 +49,8 @@ module OAuth2
       @expires_in &&= @expires_in.to_i
       @expires_at &&= @expires_at.to_i
       @expires_latency &&= @expires_latency.to_i
-      if @expires_in
-        @expires_at ||= Time.now.to_i + @expires_in
-        @expires_at -= @expires_latency if @expires_latency
-      end
+      @expires_at ||= Time.now.to_i + @expires_in if @expires_in
+      @expires_at -= @expires_latency if @expires_latency
       @options = {:mode          => opts.delete(:mode) || :header,
                   :header_format => opts.delete(:header_format) || 'Bearer %s',
                   :param_name    => opts.delete(:param_name) || 'access_token'}

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -50,7 +50,7 @@ module OAuth2
       @expires_in &&= @expires_in.to_i
       @expires_at &&= @expires_at.to_i
       @expires_latency &&= @expires_latency.to_i
-      @expires_at ||= Time.now.to_i + @expires_in if @expires_in
+      @expires_at ||= Time.now.to_i + @expires_in - @expires_latency if @expires_in
       @options = {:mode          => opts.delete(:mode) || :header,
                   :header_format => opts.delete(:header_format) || 'Bearer %s',
                   :param_name    => opts.delete(:param_name) || 'access_token'}
@@ -72,12 +72,10 @@ module OAuth2
     end
 
     # Whether or not the token is expired
-    # - The client will expire the token expires_latency seconds
-    #   prematurely to offset latency issues
     #
     # @return [Boolean]
     def expired?
-      expires? && (expires_at - expires_latency <= Time.now.to_i)
+      expires? && (expires_at <= Time.now.to_i)
     end
 
     # Refreshes the current Access Token

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe AccessToken do
 
       it 'sets it via options' do
         target = described_class.from_hash(client, hash.merge(:expires_latency => expires_latency.to_s))
-        expect(target.expires_latency).to eq 10
+        expect(target.expires_latency).to eq expires_latency
       end
 
       it 'sets it nil by default' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -75,6 +75,13 @@ RSpec.describe AccessToken do
       assert_initialized_token(target)
       expect(target.expires_at).to be_a(Integer)
     end
+
+    it 'initializes with a string expires_latency' do
+      hash = {:access_token => token, :expires_at => '1361396829', :expires_latency => '10', 'foo' => 'bar'}
+      target = described_class.from_hash(client, hash)
+      assert_initialized_token(target)
+      expect(target.expires_latency).to be_a(Integer)
+    end
   end
 
   describe '#request' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -84,16 +84,16 @@ RSpec.describe AccessToken do
       end
 
       it 'sets it 0 by default' do
-        hash = {:access_token => token, expires_in: 100}
+        hash = {:access_token => token, :expires_in => 100}
         target = described_class.from_hash(client, hash)
         expect(target.expires_latency).to eq 0
       end
 
       it 'reduces expires_at by the given amount' do
-        allow(Time).to receive(:now).and_return(1530000000)
-        hash = {:access_token => token, :expires_latency => 10, expires_in: 100}
+        allow(Time).to receive(:now).and_return(1_530_000_000)
+        hash = {:access_token => token, :expires_latency => 10, :expires_in => 100}
         target = described_class.from_hash(client, hash)
-        expect(target.expires_at).to eq 1530000090
+        expect(target.expires_at).to eq 1_530_000_090
       end
     end
   end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -76,11 +76,25 @@ RSpec.describe AccessToken do
       expect(target.expires_at).to be_a(Integer)
     end
 
-    it 'initializes with a string expires_latency' do
-      hash = {:access_token => token, :expires_at => '1361396829', :expires_latency => '10', 'foo' => 'bar'}
-      target = described_class.from_hash(client, hash)
-      assert_initialized_token(target)
-      expect(target.expires_latency).to be_a(Integer)
+    describe 'expires_latency' do
+      it 'sets it via options' do
+        hash = {:access_token => token, :expires_latency => '10'}
+        target = described_class.from_hash(client, hash)
+        expect(target.expires_latency).to eq 10
+      end
+
+      it 'sets it 0 by default' do
+        hash = {:access_token => token, expires_in: 100}
+        target = described_class.from_hash(client, hash)
+        expect(target.expires_latency).to eq 0
+      end
+
+      it 'reduces expires_at by the given amount' do
+        allow(Time).to receive(:now).and_return(1530000000)
+        hash = {:access_token => token, :expires_latency => 10, expires_in: 100}
+        target = described_class.from_hash(client, hash)
+        expect(target.expires_at).to eq 1530000090
+      end
     end
   end
 


### PR DESCRIPTION
Our assumption was that `expires_at?` is inaccurate and needs to be offset by some fixed latency amount that we never expect to exceed has been tested and this change solves the described issue #393 

<img width="862" alt="screen shot 2018-06-14 at 10 30 17" src="https://user-images.githubusercontent.com/2785359/41400651-02ae75da-6fbe-11e8-92f8-ed8b69ede729.png">

The Kred::HttpErrors (which are due to getting two 401 in a row and failing the request) have vanished competely after the deploy (second green marker from the right).

The 10 seconds are a bit arbitrary, and in worst case (where latency is zero) will simply expire the token 10seconds too early on the client side. Which I think most people can live with since expires_at often is 300s or even 1800s.