### PR TITLE
Fix duplicate redirect_uri in get_token request.

### DIFF
--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -26,6 +26,9 @@ module OAuth2
       # @note that you must also provide a :redirect_uri with most OAuth 2.0 providers
       def get_token(code, params = {}, opts = {})
         params = {'grant_type' => 'authorization_code', 'code' => code}.merge(@client.redirection_params).merge(params)
+        params.keys.each do |key|
+          params[key.to_s] = params.delete(key) if key.is_a?(Symbol)
+        end
 
         @client.get_token(params, opts)
       end


### PR DESCRIPTION
OAuth2::Client#redirection_params converts the symbol key :redirect_uri
to a string, so we have to do the same for params in get_token before merging
to avoid submitting both :redirect_uri and "redirect_uri".

Noticed this issue when using the linkedin-oauth2 gem.