### PR TITLE
Adds support for handling responses from API+JSON APIs

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -121,6 +121,6 @@ OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'appl
   MultiXml.parse(body) rescue body # rubocop:disable RescueModifier
 end
 
-OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json']) do |body|
+OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json']) do |body|
   MultiJson.load(body) rescue body # rubocop:disable RescueModifier
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe OAuth2::Response do
       expect(subject.parsed.keys.size).to eq(1)
     end
 
+    it 'parses application/vnd.api+json body' do
+      headers = {'Content-Type' => 'application/vnd.api+json'}
+      body = MultiJson.encode(:collection => {})
+      response = double('response', :headers => headers, :body => body)
+      subject = described_class.new(response)
+      expect(subject.parsed.keys.size).to eq(1)
+    end
+
     it "doesn't try to parse other content-types" do
       headers = {'Content-Type' => 'text/html'}
       body = '<!DOCTYPE html><html><head></head><body></body></html>'


### PR DESCRIPTION
For APIs that conform to the specification of jsonapi.org, responses are not being parsed.

"JSON API requires use of the JSON API media type (application/vnd.api+json) for exchanging data."
http://jsonapi.org/format/

This PR connects responses with the media type `application/vdn.api+json` to the JSON Parser. 