### PR TITLE
Fix OAuth2::Client#request send an incorrect query.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -93,8 +93,9 @@ module OAuth2
     # @option opts [Symbol] :parse @see Response::initialize
     # @yield [req] The Faraday request
     def request(verb, url, opts = {}) # rubocop:disable CyclomaticComplexity, MethodLength, Metrics/AbcSize
-      url = connection.build_url(url, opts[:params]).to_s
+      url = connection.build_url(url).to_s
       response = connection.run_request(verb, url, opts[:body], opts[:headers]) do |req|
+        req.params.update(opts[:params]) if opts[:params]
         yield(req) if block_given?
       end
       response = Response.new(response, :parse => opts[:parse])

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe AccessToken do
         VERBS.each do |verb|
           stub.send(verb, '/token/header') { |env| [200, {}, env[:request_headers]['Authorization']] }
           stub.send(verb, "/token/query?access_token=#{token}") { |env| [200, {}, Addressable::URI.parse(env[:url]).query_values['access_token']] }
+          stub.send(verb, '/token/query_string') { |env| [200, {}, CGI.unescape(Addressable::URI.parse(env[:url]).query)] }
           stub.send(verb, '/token/body') { |env| [200, {}, env[:body]] }
         end
         stub.post('/oauth/token') { |env| [200, {'Content-Type' => 'application/json'}, refresh_body] }
@@ -134,6 +135,11 @@ RSpec.describe AccessToken do
         it "sends the token in the Authorization header for a #{verb.to_s.upcase} request" do
           expect(subject.post('/token/query').body).to eq(token)
         end
+
+        it "sends a #{verb.to_s.upcase} request and options[:param_name] include [number]." do
+          subject.options[:param_name] = 'auth[1]'
+          expect(subject.__send__(verb, '/token/query_string').body).to include("auth[1]=#{token}")
+        end
       end
     end
 
@@ -145,6 +151,14 @@ RSpec.describe AccessToken do
       VERBS.each do |verb|
         it "sends the token in the Authorization header for a #{verb.to_s.upcase} request" do
           expect(subject.post('/token/body').body.split('=').last).to eq(token)
+        end
+      end
+    end
+
+    context "params include [number]" do
+      VERBS.each do |verb|
+        it "sends #{verb.to_s.upcase} correct query" do
+          expect(subject.__send__(verb, '/token/query_string', :params => {'foo[bar][1]' => 'val'}).body).to include('foo[bar][1]=val')
         end
       end
     end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe AccessToken do
       end
     end
 
-    context "params include [number]" do
+    context 'params include [number]' do
       VERBS.each do |verb|
         it "sends #{verb.to_s.upcase} correct query" do
           expect(subject.__send__(verb, '/token/query_string', :params => {'foo[bar][1]' => 'val'}).body).to include('foo[bar][1]=val')


### PR DESCRIPTION
If field name have square brackets and numbers in params options,
request will send an incorrect query.