### PR TITLE
Allow users of this gem to override the logger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 before_install:
-  - gem update --system
-  - gem install bundler
+  - gem update --system --conservative || (gem i "rubygems-update:~>2.7" --no-document && update_rubygems)
+  - gem update bundler --conservative
 
 bundler_args: --no-deployment --jobs 3 --retry 3
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ Set an environment variable, however you would [normally do that](https://github
 ENV['OAUTH_DEBUG'] = 'true'
 ```
 
+By default, debug output will go to `$stdout`. This can be overridden when
+initializing your OAuth2::Client.
+
+```ruby
+require 'oauth2'
+client = OAuth2::Client.new(
+  'client_id',
+  'client_secret',
+  :site   => 'https://example.org',
+  :logger => Logger.new('example.log', 'weekly')
+)
+```
+
 ## OAuth2::Response
 
 The AccessToken methods #get, #post, #put and #delete and the generic #request

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -24,6 +24,7 @@ module OAuth2
     # @option opts [Hash] :connection_opts ({}) Hash of connection options to pass to initialize Faraday with
     # @option opts [FixNum] :max_redirects (5) maximum number of redirects to follow
     # @option opts [Boolean] :raise_errors (true) whether or not to raise an OAuth2::Error
+    # @options opts [Logger] :logger (::Logger.new($stdout)) which logger to use when OAUTH_DEBUG is enabled
     #  on responses with 400+ status codes
     # @yield [builder] The Faraday connection builder
     def initialize(client_id, client_secret, options = {}, &block)
@@ -39,7 +40,8 @@ module OAuth2
                   :connection_opts  => {},
                   :connection_build => block,
                   :max_redirects    => 5,
-                  :raise_errors     => true}.merge(opts)
+                  :raise_errors     => true,
+                  :logger           => ::Logger.new($stdout)}.merge!(opts)
       @options[:connection_opts][:ssl] = ssl if ssl
     end
 
@@ -223,7 +225,7 @@ module OAuth2
     end
 
     def oauth_debug_logging(builder)
-      builder.response :logger, ::Logger.new($stdout), :bodies => true if ENV['OAUTH_DEBUG'] == 'true'
+      builder.response :logger, options[:logger], :bodies => true if ENV['OAUTH_DEBUG'] == 'true'
     end
   end
 end

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency 'backports', '~> 3.11'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '>= 11.0'
   spec.add_development_dependency 'rdoc', ['>= 5.0', '< 7']

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -227,6 +227,36 @@ RSpec.describe OAuth2::Client do
       expect(response.headers).to eq('Content-Type' => 'text/awesome')
     end
 
+    context 'when OAUTH_DEBUG=true and logger is set to log to /dev/null' do
+      around do |example|
+        begin
+          original = ENV['OAUTH_DEBUG']
+          ENV['OAUTH_DEBUG'] = 'true'
+
+          original_logger = subject.options[:logger]
+          subject.options[:logger] = Logger.new('/dev/null')
+
+          example.call
+        ensure
+          subject.options[:logger] = original_logger
+
+          if original.nil?
+            ENV.delete('OAUTH_DEBUG')
+          else
+            ENV['OAUTH_DEBUG'] = original
+          end
+        end
+      end
+
+      it 'will not log anything to standard out if logger is overridden to use /dev/null' do
+        output = capture_output do
+          subject.request(:get, '/success')
+        end
+
+        expect(output).to be_empty
+      end
+    end
+
     context 'when OAUTH_DEBUG=true' do
       around do |example|
         begin


### PR DESCRIPTION
  - This gem supports an existing OAUTH_DEBUG feature where log messages
  would be printed to $stdout when an ENV['OAUTH_DEBUG'] environment
  flag is raised.
  - Previously, the logging (if enabled) was hardcoded so as to always write to $stdout.
  - With this change, the gem will offer users the ability to override
  the logger used. This should provide much more freedom, allowing users
  to more easily wrangle debug output by providing other loggers and
  using other log formatters.