### PR TITLE
Fix client `fetch_token` throwing `NoMethodError` when raise_errors is set to false

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -149,7 +149,10 @@ module OAuth2
       if options[:raise_errors] && !response_contains_token
         error = Error.new(response)
         raise(error)
+      elsif !response_contains_token
+        return nil
       end
+
       build_access_token(response, access_token_opts, access_token_class)
     end
 

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -394,6 +394,34 @@ RSpec.describe OAuth2::Client do
       expect(token.response.parsed).to eq('access_token' => 'the-token')
     end
 
+    context 'when the :raise_errors flag is set to false' do
+      context 'when the request body is nil' do
+        it 'returns a nil :access_token' do
+          client = stubbed_client(:raise_errors => false) do |stub|
+            stub.post('/oauth/token') do
+              [500, {'Content-Type' => 'application/json'}, nil]
+            end
+          end
+
+          expect(client.get_token({})).to eq(nil)
+        end
+      end
+
+      context 'when the request body is not nil' do
+        it 'returns the parsed :access_token from body' do
+          client = stubbed_client do |stub|
+            stub.post('/oauth/token') do
+              [200, {'Content-Type' => 'application/json'}, MultiJson.encode('access_token' => 'the-token')]
+            end
+          end
+
+          token = client.get_token({})
+          expect(token.response).to be_a OAuth2::Response
+          expect(token.response.parsed).to eq('access_token' => 'the-token')
+        end
+      end
+    end
+
     it 'forwards given token parameters' do
       client = stubbed_client(:auth_scheme => :request_body) do |stub|
         stub.post('/oauth/token', 'arbitrary' => 'parameter', 'client_id' => 'abc', 'client_secret' => 'def') do |env|


### PR DESCRIPTION
The problem occurs when the identifier service is unreachable and we are passing the :raise_errors option set to false.

The `fetch_token` method throws `NoMethodError` while trying to perform the following code:

`response.parsed.merge(access_token_opts)`

This happens because the `response.parsed` is `nil`.