### PR TITLE
Make relative URLs just work

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -33,8 +33,8 @@ module OAuth2
       @secret = client_secret
       @site = opts.delete(:site)
       ssl = opts.delete(:ssl)
-      @options = {:authorize_url    => '/oauth/authorize',
-                  :token_url        => '/oauth/token',
+      @options = {:authorize_url    => 'oauth/authorize',
+                  :token_url        => 'oauth/token',
                   :token_method     => :post,
                   :auth_scheme      => :basic_auth,
                   :connection_opts  => {},

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -112,11 +112,7 @@ RSpec.describe OAuth2::Client do
 
       context 'when a URL with path is used in the site' do
         let(:options) do
-          {
-            :site => 'https://example.com/blog',
-            :authorize_url => 'oauth/authorize',
-            :token_url => 'oauth/token',
-          }
+          {:site => 'https://example.com/blog'}
         end
 
         it 'generates an authorization URL relative to the site' do


### PR DESCRIPTION
Thanks to #461, sites that have oauth as a subpath of another path (such as Github — `https://github.com/login/oauth/authorize`) are supported. But you have to change the config to make it work. The authorisation and token URLs are defined as absolute paths (`/oauth/authorize`). So even though, say in the GitHub case, the auth URL is indeed `oauth/authorize`,  the leading slash needs to be removed in the `authorize_url` param, otherwise you lose the `/signin` and get `https://github.com/oauth/authorize`, which 404s.

Changing the config works, but it’s annoying to do — it feels like a hack. This PR suggests a config-over-configuration approach. Define the auth and token URLs as relative paths and everything just works, no config change needed.

/cc @elliotcm 