### PR TITLE
Add checks to enforce no client_secret in authorize_url query params

### DIFF
--- a/lib/oauth2/strategy/auth_code.rb
+++ b/lib/oauth2/strategy/auth_code.rb
@@ -15,6 +15,7 @@ module OAuth2
       #
       # @param [Hash] params additional query parameters for the URL
       def authorize_url(params = {})
+        assert_valid_params(params)
         @client.authorize_url(authorize_params.merge(params))
       end
 
@@ -31,6 +32,12 @@ module OAuth2
         end
 
         @client.get_token(params, opts)
+      end
+
+    private
+
+      def assert_valid_params(params)
+        raise(ArgumentError, 'client_secret is not allowed in authorize URL query params') if params.key?(:client_secret) || params.key?('client_secret')
       end
     end
   end

--- a/lib/oauth2/strategy/implicit.rb
+++ b/lib/oauth2/strategy/implicit.rb
@@ -15,6 +15,7 @@ module OAuth2
       #
       # @param [Hash] params additional query parameters for the URL
       def authorize_url(params = {})
+        assert_valid_params(params)
         @client.authorize_url(authorize_params.merge(params))
       end
 
@@ -23,6 +24,12 @@ module OAuth2
       # @raise [NotImplementedError]
       def get_token(*)
         raise(NotImplementedError, 'The token is accessed differently in this strategy')
+      end
+
+    private
+
+      def assert_valid_params(params)
+        raise(ArgumentError, 'client_secret is not allowed in authorize URL query params') if params.key?(:client_secret) || params.key?('client_secret')
       end
     end
   end

--- a/spec/oauth2/strategy/auth_code_spec.rb
+++ b/spec/oauth2/strategy/auth_code_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OAuth2::Strategy::AuthCode do
   let(:client) do
     OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com') do |builder|
       builder.adapter :test do |stub|
-        stub.get("/oauth/token?client_id=abc&client_secret=def&code=#{code}&grant_type=authorization_code") do |env|
+        stub.get("/oauth/token?client_id=abc&code=#{code}&grant_type=authorization_code") do |env|
           case @mode
           when 'formencoded'
             [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, kvform_token]
@@ -49,6 +49,18 @@ RSpec.describe OAuth2::Strategy::AuthCode do
 
     it 'includes the type' do
       expect(subject.authorize_url).to include('response_type=code')
+    end
+
+    it 'does not include the client_secret' do
+      expect(subject.authorize_url).not_to include('client_secret=def')
+    end
+
+    it 'raises an error if the client_secret is passed in' do
+      expect { subject.authorize_url(:client_secret => 'def') }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if the client_secret is passed in with string keys' do
+      expect { subject.authorize_url('client_secret' => 'def') }.to raise_error(ArgumentError)
     end
 
     it 'includes passed in options' do

--- a/spec/oauth2/strategy/implicit_spec.rb
+++ b/spec/oauth2/strategy/implicit_spec.rb
@@ -12,6 +12,18 @@ RSpec.describe OAuth2::Strategy::Implicit do
       expect(subject.authorize_url).to include('response_type=token')
     end
 
+    it 'does not include the client_secret' do
+      expect(subject.authorize_url).not_to include('client_secret=def')
+    end
+
+    it 'raises an error if the client_secret is passed in' do
+      expect { subject.authorize_url(:client_secret => 'def') }.to raise_error(ArgumentError)
+    end
+
+    it 'raises an error if the client_secret is passed in with string keys' do
+      expect { subject.authorize_url('client_secret' => 'def') }.to raise_error(ArgumentError)
+    end
+
     it 'includes passed in options' do
       cb = 'http://myserver.local/oauth/callback'
       expect(subject.authorize_url(:redirect_uri => cb)).to include("redirect_uri=#{CGI.escape(cb)}")


### PR DESCRIPTION
Fix for #193 

Raise error if the `implicit`, and `auth_code` grant types are passed the `client_secret` as a parameter for the `authorize_url`.