### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -22,6 +22,14 @@ Gem::Specification.new do |spec|
   spec.summary       = 'A Ruby wrapper for the OAuth 2.0 protocol.'
   spec.version       = OAuth2::Version
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/oauth-xx/oauth2/issues',
+    'changelog_uri'     => "https://github.com/oauth-xx/oauth2/blob/v#{spec.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/oauth2/#{spec.version}",
+    'source_code_uri'   => "https://github.com/oauth-xx/oauth2/tree/v#{spec.version}",
+    'wiki_uri'          => 'https://github.com/oauth-xx/oauth2/wiki'
+  }
+
   spec.require_paths = %w[lib]
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/oauth2 and be available via the rubygems API after the next release.