### PR TITLE
Add the ability to use TLS client auth when requesting access token

### DIFF
--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -25,6 +25,8 @@ module OAuth2
         apply_basic_auth(params)
       when :request_body
         apply_params_auth(params)
+      when :tls_client_auth
+        apply_tls_params_auth(params)
       else
         raise NotImplementedError
       end
@@ -40,6 +42,11 @@ module OAuth2
     # already set.
     def apply_params_auth(params)
       {'client_id' => id, 'client_secret' => secret}.merge(params)
+    end
+
+    # When using the TLS client auth scheme, we don't want to send the secret
+    def apply_tls_params_auth(params)
+      { 'client_id' => id }.merge(params)
     end
 
     # Adds an `Authorization` header with Basic Auth credentials if and only if

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe OAuth2::Authenticator do
           :headers => {'A' => 'b'}
         )
       end
+
+      context 'using tls client authentication' do
+        let(:mode) { :tls_client_auth }
+
+        it 'does not add client_secret' do
+          output = subject.apply({})
+          expect(output).to eq('client_id' => 'foo')
+        end
+      end
     end
 
     context 'with Basic authentication' do

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe OAuth2::Client do
             subject.request(:get, '/success')
             subject.request(:get, '/reflect', :body => 'this is magical')
           end
-          expect(printed).to match(/DEBUG -- request: User-Agent: "Faraday v.+"/)
-          expect(printed).to match 'DEBUG -- response: Content-Type: "text/awesome'
-          expect(printed).to match 'DEBUG -- response: yay'
-          expect(printed).to match 'DEBUG -- request: this is magical'
-          expect(printed).to match 'DEBUG -- response: this is magical'
+          expect(printed).to match 'request: GET https://api.example.com/success'
+          expect(printed).to match 'response: Content-Type:'
+          expect(printed).to match 'response: yay'
+          expect(printed).to match 'request: this is magical'
+          expect(printed).to match 'response: this is magical'
         end
       end
       context 'when OAUTH_DEBUG=false' do
@@ -279,9 +279,9 @@ RSpec.describe OAuth2::Client do
             subject.request(:get, '/success')
           end
           logs = [
-              'INFO -- request: GET https://api.example.com/success',
-              'INFO -- response: Status 200',
-              'DEBUG -- response: Content-Type: "text/awesome"'
+              'request: GET https://api.example.com/success',
+              'response: Status 200',
+              'response: Content-Type: "text/awesome"'
           ]
           expect(output).to include(*logs)
         end


### PR DESCRIPTION
When making the request to retrieve an access token, if the API requires
you to use TLS client auth as the authentication mechanism then it will
fail if the client secret is sent. For this auth type, only the client
ID should be sent.

We do not currently allow the developer to customise this; we set the
client ID and secret by default for all access token requests.

This PR adds an extra section to the case statement in
Authenticator#apply to add the desired functionality; when passing in
`tls_client_auth` as the auth mode, the client secret will be omitted
from the request.

**Update:**
There were some failing specs due to the logging in the new version of Faraday (1v1.0.0) being in a different format to that which the test suite expected. This PR also addresses this. The fix was to remove the log level markers "INFO/DEBUG".