### PR TITLE
Handle relative location in a 301 redirect.

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -110,7 +110,8 @@ module OAuth2
           verb = :get
           opts.delete(:body)
         end
-        request(verb, response.headers['location'], opts)
+        full_location = response.response.env.url.merge(response.headers['location'])
+        request(verb, full_location, opts)
       when 200..299, 300..399
         # on non-redirecting 3xx statuses, just return the response
         response


### PR DESCRIPTION
This is a simple change to merge a relative reference (1) or absolute URI (2) from the location header into the original request URI.

If there are any barriers to this being merged, please let me know.

1. https://tools.ietf.org/html/rfc3986#section-4.2
2. https://tools.ietf.org/html/rfc3986#section-4.3