### PR TITLE
Remove log level markers from specs matching Faraday log output

### DIFF
--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe OAuth2::Client do
             subject.request(:get, '/success')
             subject.request(:get, '/reflect', :body => 'this is magical')
           end
-          expect(printed).to match(/DEBUG -- request: User-Agent: "Faraday v.+"/)
-          expect(printed).to match 'DEBUG -- response: Content-Type: "text/awesome'
-          expect(printed).to match 'DEBUG -- response: yay'
-          expect(printed).to match 'DEBUG -- request: this is magical'
-          expect(printed).to match 'DEBUG -- response: this is magical'
+          expect(printed).to match(/INFO -- request: User-Agent: "Faraday v.+"/)
+          expect(printed).to match 'INFO -- response: Content-Type: "text/awesome'
+          expect(printed).to match 'INFO -- response: yay'
+          expect(printed).to match 'INFO -- request: this is magical'
+          expect(printed).to match 'INFO -- response: this is magical'
         end
       end
       context 'when OAUTH_DEBUG=false' do
@@ -281,7 +281,7 @@ RSpec.describe OAuth2::Client do
           logs = [
               'INFO -- request: GET https://api.example.com/success',
               'INFO -- response: Status 200',
-              'DEBUG -- response: Content-Type: "text/awesome"'
+              'INFO -- response: Content-Type: "text/awesome"'
           ]
           expect(output).to include(*logs)
         end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -194,11 +194,11 @@ RSpec.describe OAuth2::Client do
             subject.request(:get, '/success')
             subject.request(:get, '/reflect', :body => 'this is magical')
           end
-          expect(printed).to match(/INFO -- request: User-Agent: "Faraday v.+"/)
-          expect(printed).to match 'INFO -- response: Content-Type: "text/awesome'
-          expect(printed).to match 'INFO -- response: yay'
-          expect(printed).to match 'INFO -- request: this is magical'
-          expect(printed).to match 'INFO -- response: this is magical'
+          expect(printed).to match(/ -- request: User-Agent: "Faraday v.+"/)
+          expect(printed).to match ' -- response: Content-Type: "text/awesome'
+          expect(printed).to match ' -- response: yay'
+          expect(printed).to match ' -- request: this is magical'
+          expect(printed).to match ' -- response: this is magical'
         end
       end
       context 'when OAUTH_DEBUG=false' do
@@ -279,9 +279,9 @@ RSpec.describe OAuth2::Client do
             subject.request(:get, '/success')
           end
           logs = [
-              'INFO -- request: GET https://api.example.com/success',
-              'INFO -- response: Status 200',
-              'INFO -- response: Content-Type: "text/awesome"'
+              ' -- request: GET https://api.example.com/success',
+              ' -- response: Status 200',
+              ' -- response: Content-Type: "text/awesome"'
           ]
           expect(output).to include(*logs)
         end


### PR DESCRIPTION
Faraday v1.0.0 changed how requests and responses are logged: previously, the headers and bodies were logged at `DEBUG` and the other details were logged at `INFO`. https://github.com/lostisland/faraday/pull/1079 changed the logging to always use the same level for all the details, and defaulted to `INFO`.

Some `oauth2` specs check if the requests & responses are as expected by examining logging from `faraday`, and include the log level markers in the expected text. Updating the markers to `INFO` works fine, except for Ruby 2.2: [`faraday-1.0.0` requires a Ruby version greater than `2.3`](https://github.com/lostisland/faraday/blob/099dd45f63ff99bbb343eebf7504a3cf0b10bc63/faraday.gemspec#L19) and thus on Ruby 2.2 the previous version of `faraday` is used. [`oauth2` tests against Ruby 2.2](https://github.com/oauth-xx/oauth2/blob/3bef9feff5de9d46b35c7423061508e5092b1eac/.travis.yml#L35), so it need the expected log output to match on both `faraday-0.17.3` and `faraday-1.0.0`.

This PR addresses https://github.com/oauth-xx/oauth2/pull/489 & https://github.com/oauth-xx/oauth2/pull/492.