### PR TITLE
Adds support for private_key_jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ token = client.auth_code.get_token('code_value', :redirect_uri => 'http://localh
 You can always use the #request method on the OAuth2::Client instance to make
 requests for tokens for any Authentication grant type.
 
+
 ## Supported Ruby Versions
 
 This library aims to support and is [tested against][travis] the following Ruby

--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -25,8 +25,8 @@ module OAuth2
         apply_basic_auth(params)
       when :request_body
         apply_params_auth(params)
-      when :tls_client_auth
-        apply_tls_params_auth(params)
+      when :tls_client_auth, :private_key_jwt
+        apply_client_id(params)
       else
         raise NotImplementedError
       end
@@ -44,8 +44,9 @@ module OAuth2
       {'client_id' => id, 'client_secret' => secret}.merge(params)
     end
 
-    # When using the TLS client auth scheme, we don't want to send the secret
-    def apply_tls_params_auth(params)
+    # When using schemes that don't require the client_secret to be passed ( TLS Client auth, Private Key JWT etc),
+    # we don't want to send the secret
+    def apply_client_id(params)
       { 'client_id' => id }.merge(params)
     end
 

--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -25,8 +25,10 @@ module OAuth2
         apply_basic_auth(params)
       when :request_body
         apply_params_auth(params)
-      when :tls_client_auth, :private_key_jwt
+      when :tls_client_auth
         apply_client_id(params)
+      when :private_key_jwt
+        params
       else
         raise NotImplementedError
       end

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe OAuth2::Authenticator do
           expect(output).to eq('client_id' => 'foo')
         end
       end
+
+      context 'using private key jwt authentication' do
+        let(:mode) { :private_key_jwt }
+
+        it 'does not add client_secret' do
+          output = subject.apply({})
+          expect(output).to eq('client_id' => 'foo')
+        end
+      end
     end
 
     context 'with Basic authentication' do

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -49,9 +49,9 @@ RSpec.describe OAuth2::Authenticator do
       context 'using private key jwt authentication' do
         let(:mode) { :private_key_jwt }
 
-        it 'does not add client_secret' do
+        it 'does not include client_id or client_secret' do
           output = subject.apply({})
-          expect(output).to eq('client_id' => 'foo')
+          expect(output).to eq({})
         end
       end
     end


### PR DESCRIPTION
A recent merge added support for tls_client_auth scheme by providing an auth scheme value that would only add the client_id to the request body. The Private Key JWT scheme includes the client_id in the client_assertion and so is not needed in the main request body. 

This PR simply returns unaltered params when private_key_jwt is specified as the auth_scheme

