### PR TITLE
add support for private_key_jwt and tls_client_auth

### DIFF
--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -25,6 +25,10 @@ module OAuth2
         apply_basic_auth(params)
       when :request_body
         apply_params_auth(params)
+      when :tls_client_auth
+        apply_client_id(params)
+      when :private_key_jwt
+        params
       else
         raise NotImplementedError
       end
@@ -40,6 +44,12 @@ module OAuth2
     # already set.
     def apply_params_auth(params)
       {'client_id' => id, 'client_secret' => secret}.merge(params)
+    end
+
+    # When using schemes that don't require the client_secret to be passed i.e TLS Client Auth,
+    # we don't want to send the secret
+    def apply_client_id(params)
+      { 'client_id' => id }.merge(params)
     end
 
     # Adds an `Authorization` header with Basic Auth credentials if and only if

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -38,6 +38,24 @@ describe OAuth2::Authenticator do
           :headers => {'A' => 'b'}
         )
       end
+
+      context 'using tls client authentication' do
+        let(:mode) { :tls_client_auth }
+
+        it 'does not add client_secret' do
+          output = subject.apply({})
+          expect(output).to eq('client_id' => 'foo')
+        end
+      end
+
+      context 'using private key jwt authentication' do
+        let(:mode) { :private_key_jwt }
+
+        it 'does not add client_secret or client_id' do
+          output = subject.apply({})
+          expect(output).to eq({})
+        end
+      end
     end
 
     context 'with Basic authentication' do

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -251,9 +251,9 @@ describe OAuth2::Client do
           subject.request(:get, '/success')
         end
         logs = [
-          'INFO -- request: GET https://api.example.com/success',
-          'INFO -- response: Status 200',
-          'DEBUG -- response: Content-Type: "text/awesome"'
+          '-- request: GET https://api.example.com/success',
+          '-- response: Status 200',
+          '-- response: Content-Type: "text/awesome"'
         ]
         expect(output).to include(*logs)
       end


### PR DESCRIPTION
A recent merge to master added support for tls_client_auth scheme by providing an auth scheme value that would only add the client_id to the request body. The Private Key JWT scheme includes the client_id in the client_assertion and so is not needed in the main request body.

This PR simply returns unaltered params when private_key_jwt is specified as the auth_scheme and adds tls support for v1.4

I have also dropped the INFO/DEBUG from the client spec as it appears to switch between the two depending on the ruby version. I thought this was neater and simpler than writing a complex set of contexts for different versions. Especially considering that the important aspect is the output information rather than the label.