### PR TITLE
CI: Drop unused Travis sudo: false directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,5 +69,3 @@ matrix:
       gemfile: gemfiles/ruby_head.gemfile
     - rvm: truffleruby
       gemfile: gemfiles/truffleruby.gemfile
-
-sudo: false


### PR DESCRIPTION
This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).