### PR TITLE
Avoid YARD API annotation warnings

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -6,8 +6,8 @@ module OAuth2
     class << self
       # Initializes an AccessToken from a Hash
       #
-      # @param [Client] the OAuth2::Client instance
-      # @param [Hash] a hash of AccessToken property values
+      # @param client [Client] the OAuth2::Client instance
+      # @param hash [Hash] a hash of AccessToken property values
       # @return [AccessToken] the initalized AccessToken
       def from_hash(client, hash)
         hash = hash.dup

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -14,17 +14,17 @@ module OAuth2
     #
     # @param [String] client_id the client_id value
     # @param [String] client_secret the client_secret value
-    # @param [Hash] opts the options to create the client with
-    # @option opts [String] :site the OAuth2 provider site host
-    # @option opts [String] :redirect_uri the absolute URI to the Redirection Endpoint for use in authorization grants and token exchange
-    # @option opts [String] :authorize_url ('/oauth/authorize') absolute or relative URL path to the Authorization endpoint
-    # @option opts [String] :token_url ('/oauth/token') absolute or relative URL path to the Token endpoint
-    # @option opts [Symbol] :token_method (:post) HTTP method to use to request token (:get or :post)
-    # @option opts [Symbol] :auth_scheme (:basic_auth) HTTP method to use to authorize request (:basic_auth or :request_body)
-    # @option opts [Hash] :connection_opts ({}) Hash of connection options to pass to initialize Faraday with
-    # @option opts [FixNum] :max_redirects (5) maximum number of redirects to follow
-    # @option opts [Boolean] :raise_errors (true) whether or not to raise an OAuth2::Error
-    # @options opts [Logger] :logger (::Logger.new($stdout)) which logger to use when OAUTH_DEBUG is enabled
+    # @param [Hash] options the options to create the client with
+    # @option options [String] :site the OAuth2 provider site host
+    # @option options [String] :redirect_uri the absolute URI to the Redirection Endpoint for use in authorization grants and token exchange
+    # @option options [String] :authorize_url ('/oauth/authorize') absolute or relative URL path to the Authorization endpoint
+    # @option options [String] :token_url ('/oauth/token') absolute or relative URL path to the Token endpoint
+    # @option options [Symbol] :token_method (:post) HTTP method to use to request token (:get or :post)
+    # @option options [Symbol] :auth_scheme (:basic_auth) HTTP method to use to authorize request (:basic_auth or :request_body)
+    # @option options [Hash] :connection_opts ({}) Hash of connection options to pass to initialize Faraday with
+    # @option options [FixNum] :max_redirects (5) maximum number of redirects to follow
+    # @option options [Boolean] :raise_errors (true) whether or not to raise an OAuth2::Error
+    # @option options [Logger] :logger (::Logger.new($stdout)) which logger to use when OAUTH_DEBUG is enabled
     #  on responses with 400+ status codes
     # @yield [builder] The Faraday connection builder
     def initialize(client_id, client_secret, options = {}, &block)
@@ -47,7 +47,7 @@ module OAuth2
 
     # Set the site host
     #
-    # @param [String] the OAuth2 provider site host
+    # @param value [String] the OAuth2 provider site host
     def site=(value)
       @connection = nil
       @site = value
@@ -127,9 +127,9 @@ module OAuth2
 
     # Initializes an AccessToken by making a request to the token endpoint
     #
-    # @param [Hash] params a Hash of params for the token endpoint
-    # @param [Hash] access token options, to pass to the AccessToken object
-    # @param [Class] class of access token for easier subclassing OAuth2::AccessToken
+    # @param params [Hash] a Hash of params for the token endpoint
+    # @param access_token_opts [Hash] access token options, to pass to the AccessToken object
+    # @param access_token_class [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       params = authenticator.apply(params)

--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -9,7 +9,7 @@ module OAuth2
     #
     # @param [AccessToken] token the OAuth2::Token instance
     # @option [String] secret the secret key value
-    # @param [Hash] opts the options to create the Access Token with
+    # @param [Hash] options the options to create the Access Token with
     # @see MACToken#initialize
     def self.from_access_token(token, secret, options = {})
       new(token.client, token.token, secret, token.params.merge(:refresh_token => token.refresh_token, :expires_in => token.expires_in, :expires_at => token.expires_at).merge(options))
@@ -76,7 +76,7 @@ module OAuth2
     # @param [Fixnum] timestamp the timestamp of the request in seconds since epoch
     # @param [String] nonce the MAC header nonce
     # @param [Symbol] verb the HTTP request method
-    # @param [String] url the HTTP URL path of the request
+    # @param [String] uri the HTTP URL path of the request
     def signature(timestamp, nonce, verb, uri)
       signature = [
         timestamp,


### PR DESCRIPTION
This PR amends the API reference documentation.

Before this change, these were the warnings:

```
Building YARD (yri) index for oauth2-1.4.4...
lib/oauth2/client.rb:17: [UnknownParam] @param tag has unknown parameter name: opts
lib/oauth2/client.rb:48: [UnknownParam] @param tag has unknown parameter name: the
lib/oauth2/client.rb:132: [UnknownParam] @param tag has unknown parameter name: access
lib/oauth2/client.rb:133: [UnknownParam] @param tag has unknown parameter name: class
lib/oauth2/mac_token.rb:12: [UnknownParam] @param tag has unknown parameter name: opts
lib/oauth2/mac_token.rb:79: [UnknownParam] @param tag has unknown parameter name: url. Did you mean `uri`?
lib/oauth2/access_token.rb:9: [UnknownParam] @param tag has unknown parameter name: the
lib/oauth2/access_token.rb:10: [UnknownParam] @param tag has unknown parameter name: a
```