### PR TITLE
Fix missing custom headers in get_token

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -132,6 +132,10 @@ module OAuth2
     # @param access_token_class [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      if !params[:headers] && params['headers']
+        params[:headers] = params.delete('headers')
+      end
+
       params = authenticator.apply(params)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
       headers = params.delete(:headers) || {}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -134,9 +134,17 @@ module OAuth2
     # @param access_token_class [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-      params.transform_keys! do |key|
-        RESERVED_PARAM_KEYS.include?(key) ? key.to_sym : key
-      end
+      # if ruby version >= 2.4
+      # params.transform_keys! do |key|
+      #   RESERVED_PARAM_KEYS.include?(key) ? key.to_sym : key
+      # end
+      params = params.map do |key, value|
+        if RESERVED_PARAM_KEYS.include?(key)
+          [key.to_sym, value]
+        else
+          [key, value]
+        end
+      end.to_h
 
       params = authenticator.apply(params)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -4,6 +4,8 @@ require 'logger'
 module OAuth2
   # The OAuth2::Client class
   class Client # rubocop:disable Metrics/ClassLength
+    RESERVED_PARAM_KEYS = ['headers', 'parse'].freeze
+
     attr_reader :id, :secret, :site
     attr_accessor :options
     attr_writer :connection
@@ -132,8 +134,8 @@ module OAuth2
     # @param access_token_class [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-      if !params[:headers] && params['headers']
-        params[:headers] = params.delete('headers')
+      params.transform_keys! do |key|
+        RESERVED_PARAM_KEYS.include?(key) ? key.to_sym : key
       end
 
       params = authenticator.apply(params)

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', ['>= 1.2', '< 3']
 
-  spec.add_dependency 'activesupport', ['>= 4.0']
-
   spec.authors       = ['Peter Boling', 'Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['peter.boling@gmail.com']

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_xml', '~> 0.5'
   spec.add_dependency 'rack', ['>= 1.2', '< 3']
 
+  spec.add_dependency 'activesupport', ['>= 4.0']
+
   spec.authors       = ['Peter Boling', 'Michael Bleigh', 'Erik Michaels-Ober']
   spec.description   = 'A Ruby wrapper for the OAuth 2.0 protocol built with a similar style to the original OAuth spec.'
   spec.email         = ['peter.boling@gmail.com']

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -168,33 +168,65 @@ RSpec.describe OAuth2::Client do
       end
     end
 
-    context 'custom headers' do
-      it 'adds the custom headres to request' do
-        client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
-          builder.adapter :test do |stub|
-            stub.post('/oauth/token', auth_code_params) do |env|
-              expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
-              [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+    describe 'custom headers' do
+      context 'string key headers' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
             end
           end
+          header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
         end
-        header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
-        client.auth_code.get_token('code', header_params)
       end
-    end
 
-    context 'custom headers with basic auth' do
-      it 'adds the custom headres to request' do
-        client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
-          builder.adapter :test do |stub|
-            stub.post('/oauth/token') do |env|
-              expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
-              [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+      context 'symbol key headers' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
             end
           end
+          header_params = {headers: { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
         end
-        header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
-        client.auth_code.get_token('code', header_params)
+      end
+
+      context 'string key custom headers with basic auth' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
+      end
+
+      context 'symbol key custom headers with basic auth' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {headers: { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
       end
     end
   end

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -167,6 +167,36 @@ RSpec.describe OAuth2::Client do
         client.auth_code.get_token('code')
       end
     end
+
+    context 'custom headers' do
+      it 'adds the custom headres to request' do
+        client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
+          builder.adapter :test do |stub|
+            stub.post('/oauth/token', auth_code_params) do |env|
+              expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+              [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+            end
+          end
+        end
+        header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+        client.auth_code.get_token('code', header_params)
+      end
+    end
+
+    context 'custom headers with basic auth' do
+      it 'adds the custom headres to request' do
+        client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+          builder.adapter :test do |stub|
+            stub.post('/oauth/token') do |env|
+              expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+              [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+            end
+          end
+        end
+        header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+        client.auth_code.get_token('code', header_params)
+      end
+    end
   end
 
   describe '#connection' do


### PR DESCRIPTION
I propose this way to quickly get over #498 
If we use `HashWithIndifferentAccess` or anything similar, we must revise and change whole system inputs, outputs. Currently, system returns hashes with mixed keys in string and symbol. 
This change looks like a patch but it has 2 pros besides fixing issue. 

- Simple implement, we needn't add complex things like HashWithIndifferentAccess
- Keep others interfaces same. 

After, we could have a bigger implement to standardize inputs, outputs. 