### PR TITLE
[1-4-stable] Fix missing custom headers in get_token (#512)

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -4,6 +4,8 @@ require 'logger'
 module OAuth2
   # The OAuth2::Client class
   class Client # rubocop:disable Metrics/ClassLength
+    RESERVED_PARAM_KEYS = ['headers', 'parse'].freeze
+
     attr_reader :id, :secret, :site
     attr_accessor :options
     attr_writer :connection
@@ -132,7 +134,15 @@ module OAuth2
     # @param [Hash] access token options, to pass to the AccessToken object
     # @param [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
-    def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+      params = params.map do |key, value|
+        if RESERVED_PARAM_KEYS.include?(key)
+          [key.to_sym, value]
+        else
+          [key, value]
+        end
+      end.to_h
+
       params = Authenticator.new(id, secret, options[:auth_scheme]).apply(params)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}
       headers = params.delete(:headers) || {}

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -141,7 +141,8 @@ module OAuth2
         else
           [key, value]
         end
-      end.to_h
+      end
+      params = Hash[params]
 
       params = Authenticator.new(id, secret, options[:auth_scheme]).apply(params)
       opts = {:raise_errors => options[:raise_errors], :parse => params.delete(:parse)}

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -157,6 +157,68 @@ describe OAuth2::Client do
         client.auth_code.get_token('code')
       end
     end
+
+    describe 'custom headers' do
+      context 'string key headers' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
+      end
+
+      context 'symbol key headers' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com', :auth_scheme => :request_body) do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {headers: { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
+      end
+
+      context 'string key custom headers with basic auth' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {'headers' => { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
+      end
+
+      context 'symbol key custom headers with basic auth' do
+        it 'adds the custom headers to request' do
+          client = described_class.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+            builder.adapter :test do |stub|
+              stub.post('/oauth/token') do |env|
+                expect(env.request_headers).to include({'CustomHeader' => 'CustomHeader'})
+                [200, {'Content-Type' => 'application/json'}, '{"access_token":"token"}']
+              end
+            end
+          end
+          header_params = {headers: { 'CustomHeader' => 'CustomHeader' }}
+          client.auth_code.get_token('code', header_params)
+        end
+      end
+    end
   end
 
   describe '#request' do


### PR DESCRIPTION
Fix https://github.com/oauth-xx/oauth2/issues/498 to `1-4-stable` branch. 

Pick from PR https://github.com/oauth-xx/oauth2/pull/512