### PR TITLE
Add Client option for access_token_class

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -28,6 +28,7 @@ module OAuth2
     # @option options [Boolean] :raise_errors (true) whether or not to raise an OAuth2::Error
     # @option options [Logger] :logger (::Logger.new($stdout)) which logger to use when OAUTH_DEBUG is enabled
     #  on responses with 400+ status codes
+    # @option options [Class] :access_token_class (AccessToken) class used to create access tokens
     # @yield [builder] The Faraday connection builder
     def initialize(client_id, client_secret, options = {}, &block)
       opts = options.dup
@@ -35,15 +36,16 @@ module OAuth2
       @secret = client_secret
       @site = opts.delete(:site)
       ssl = opts.delete(:ssl)
-      @options = {:authorize_url    => 'oauth/authorize',
-                  :token_url        => 'oauth/token',
-                  :token_method     => :post,
-                  :auth_scheme      => :basic_auth,
-                  :connection_opts  => {},
-                  :connection_build => block,
-                  :max_redirects    => 5,
-                  :raise_errors     => true,
-                  :logger           => ::Logger.new($stdout)}.merge!(opts)
+      @options = {:authorize_url      => 'oauth/authorize',
+                  :token_url          => 'oauth/token',
+                  :token_method       => :post,
+                  :auth_scheme        => :basic_auth,
+                  :connection_opts    => {},
+                  :connection_build   => block,
+                  :max_redirects      => 5,
+                  :raise_errors       => true,
+                  :logger             => ::Logger.new($stdout),
+                  :access_token_class => AccessToken}.merge!(opts)
       @options[:connection_opts][:ssl] = ssl if ssl
     end
 
@@ -133,7 +135,7 @@ module OAuth2
     # @param access_token_opts [Hash] access token options, to pass to the AccessToken object
     # @param access_token_class [Class] class of access token for easier subclassing OAuth2::AccessToken
     # @return [AccessToken] the initialized AccessToken
-    def get_token(params, access_token_opts = {}, access_token_class = AccessToken) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
+    def get_token(params, access_token_opts = {}, access_token_class = options[:access_token_class]) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
       # if ruby version >= 2.4
       # params.transform_keys! do |key|
       #   RESERVED_PARAM_KEYS.include?(key) ? key.to_sym : key

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -431,6 +431,20 @@ RSpec.describe OAuth2::Client do
       expect(token.token).to eq('the-token')
     end
 
+    it 'returns a configured access token given by client.options[:access_token_class]' do
+      NewAccessToken = Class.new(AccessToken)
+      client = stubbed_client(access_token_class: NewAccessToken) do |stub|
+        stub.post('/oauth/token') do
+          [200, {'Content-Type' => 'application/json'}, MultiJson.encode('access_token' => 'the-token')]
+        end
+      end
+
+      token = client.get_token({})
+      expect(token).to be_a NewAccessToken
+      expect(token.token).to eq('the-token')
+    end
+
+
     it 'authenticates with request parameters' do
       client = stubbed_client(:auth_scheme => :request_body) do |stub|
         stub.post('/oauth/token', 'client_id' => 'abc', 'client_secret' => 'def') do |env|


### PR DESCRIPTION
## The Problem

There is no way to use `OAuth2::Client` strategies such as `auth_code` AND supply a custom access_token_class.

`OAuth2::Client.get_token` has an optional argument for the access_token_class to instantiate. 
However, callers of it have to know to use it and none of the strategies do so. This means the anyone needing a custom access_token_class, #243 or #511, need to jump through hoops to get the behavior they want. For example subclassing `OAuth2::Client` just to change the default class

## What I did

Added a new option, `access_token_class`, to `OAuth2::Client` which is used as the default `access_token_class` for all calls to `get_token`.

This is a safe, non-breaking change.