### PR TITLE
Defer parsing and validation of access tokens to the AccessToken class

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -11,7 +11,9 @@ module OAuth2
       # @return [AccessToken] the initalized AccessToken
       def from_hash(client, hash)
         hash = hash.dup
-        new(client, hash.delete('access_token') || hash.delete(:access_token), hash)
+        token =  hash.delete('access_token') || hash.delete(:access_token)
+        return unless token
+        new(client, token, hash)
       end
 
       # Initializes an AccessToken from a key/value application/x-www-form-urlencoded string

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -158,17 +158,15 @@ module OAuth2
       end
       opts[:headers].merge!(headers)
       response = request(options[:token_method], token_url, opts)
-      response_contains_token = response.parsed.is_a?(Hash) &&
-                                (response.parsed['access_token'] || response.parsed['id_token'])
 
-      if options[:raise_errors] && !response_contains_token
+      access_token = build_access_token(response, access_token_opts, access_token_class)
+
+      if options[:raise_errors] && !access_token
         error = Error.new(response)
         raise(error)
-      elsif !response_contains_token
-        return nil
       end
 
-      build_access_token(response, access_token_opts, access_token_class)
+      access_token
     end
 
     # The Authorization Code strategy
@@ -240,6 +238,7 @@ module OAuth2
     #
     # @return [AccessToken] the initialized AccessToken
     def build_access_token(response, access_token_opts, access_token_class)
+      return unless response.parsed.is_a?(Hash)
       access_token_class.from_hash(self, response.parsed.merge(access_token_opts)).tap do |access_token|
         access_token.response = response if access_token.respond_to?(:response=)
       end


### PR DESCRIPTION
This is an alternative take on a solution for #511

Needs #516 to be able to fix the failing specs and add more spec coverage.

With this fix in place the solution to #511 would be to subclass `AccessToken`. Something like this:

```ruby
class PinterestAccessToken < OAuth2::AccessToken
  class << self
    def from_hash(client, hash)
      hash = hash.dup
      token =  hash.dig(:data, :access_token)
      return unless token
      new(client, token, hash)
    end
  end

  #... any class level changes
end
```

Similarly the Microsoft id_token only problem could be solved with

```ruby
class MicrosoftAccessToken < OAuth2::AccessToken
  class << self
    def from_hash(client, hash)
      hash = hash.dup
      token =  hash.delete("access_token") || hash.delete("id_token")
      return unless token
      new(client, token, hash)
    end
  end
end
```

This is likely a breaking change as it requires a new API for anyone that has subclassed `AccessToken`. 