### PR TITLE
Add extract_access_token option to OAuth2::Client

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -3,6 +3,7 @@ module OAuth2
     attr_reader :client, :token, :expires_in, :expires_at, :params
     attr_accessor :options, :refresh_token
 
+    # Should these methods be deprecated?
     class << self
       # Initializes an AccessToken from a Hash
       #


### PR DESCRIPTION
Make `OAuth2::Client` responsible for parsing the access_token from the token response by adding an `extract_access_token` option.
This enables clients to supply their own extraction logic so that we can support various use cases like Pintrest and Microsoft that have their own particular wrinkles. 

This is a combination of ideas #516 and #517 but based of the 1-4-stable branch and in a way that is a non-breaking change.

There will be a little bit of work to merge this into master but there is a clear path there too.