### PR TITLE
Backport raise errors to 1.4 Stable

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -166,7 +166,10 @@ module OAuth2
       if options[:raise_errors] && !access_token
         error = Error.new(response)
         raise(error)
+      elsif !access_token
+        return nil
       end
+      
       access_token
     end
 

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -492,8 +492,8 @@ describe OAuth2::Client do
           end
 
           token = client.get_token({})
-          expect(token.response).to be_a OAuth2::Response
-          expect(token.response.parsed).to eq('access_token' => 'the-token')
+          expect(token).to be_a OAuth2::AccessToken
+          expect(token.token).to eq('the-token')
         end
       end
     end


### PR DESCRIPTION
The problem occurs when the identifier service is unreachable and we are passing the :raise_errors option set to false.

The fetch_token method throws NoMethodError while trying to perform the following code:

response.parsed.merge(access_token_opts)

This happens because the response.parsed is nil.

Backported from #460 
Closes #459 