### PR TITLE
Remove reliance on globally included OAuth2 in tests (1-4-stable)

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -166,6 +166,7 @@ module OAuth2
       access_token = begin
         build_access_token(response, access_token_opts, extract_access_token)
       rescue StandardError
+        raise
         nil
       end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -30,11 +30,6 @@ end
 
 Faraday.default_adapter = :test
 
-# This is dangerous - HERE BE DRAGONS.
-# It allows us to refer to classes without the namespace, but at what cost?!?
-# TODO: Refactor to use explicit references everywhere
-include OAuth2
-
 RSpec.configure do |conf|
   conf.include SilentStream
 end

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -1,10 +1,10 @@
-describe AccessToken do
+describe OAuth2::AccessToken do
   subject { described_class.new(client, token) }
 
   let(:token) { 'monkey' }
   let(:refresh_body) { MultiJson.encode(:access_token => 'refreshed_foo', :expires_in => 600, :refresh_token => 'refresh_bar') }
   let(:client) do
-    Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+    OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
       builder.request :url_encoded
       builder.adapter :test do |stub|
         VERBS.each do |verb|

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -371,7 +371,7 @@ describe OAuth2::Client do
         let(:extract_access_token) do
           proc do |client, hash|
             token = hash['data']['access_token']
-            AccessToken.new(client, token, hash)
+            OAuth2::AccessToken.new(client, token, hash)
           end
         end
 
@@ -384,10 +384,10 @@ describe OAuth2::Client do
 
       context 'with depracted Class.from_hash option' do
         let(:extract_access_token) do
-          CustomAccessToken = Class.new(AccessToken)
+          CustomAccessToken = Class.new(OAuth2::AccessToken)
           CustomAccessToken.define_singleton_method(:from_hash) do |client, hash|
             token = hash['data']['access_token']
-            AccessToken.new(client, token, hash)
+            OAuth2::AccessToken.new(client, token, hash)
           end
           CustomAccessToken
         end

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -1,9 +1,9 @@
-describe MACToken do
+describe OAuth2::MACToken do
   subject { described_class.new(client, token, 'abc123') }
 
   let(:token) { 'monkey' }
   let(:client) do
-    Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
+    OAuth2::Client.new('abc', 'def', :site => 'https://api.example.com') do |builder|
       builder.request :url_encoded
       builder.adapter :test do |stub|
         VERBS.each do |verb|
@@ -89,7 +89,7 @@ describe MACToken do
     subject { described_class.from_access_token(access_token, 'hello') }
 
     let(:access_token) do
-      AccessToken.new(
+      OAuth2::AccessToken.new(
         client, token,
         :expires_at => 1,
         :expires_in => 1,

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -8,7 +8,7 @@ describe OAuth2::Response do
       response = double('response', :headers => headers,
                                     :status => status,
                                     :body => body)
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.headers).to eq(headers)
       expect(subject.status).to eq(status)
       expect(subject.body).to eq(body)
@@ -43,7 +43,7 @@ describe OAuth2::Response do
       headers = {'Content-Type' => 'application/x-www-form-urlencoded'}
       body = 'foo=bar&answer=42'
       response = double('response', :headers => headers, :body => body)
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.parsed.keys.size).to eq(2)
       expect(subject.parsed['foo']).to eq('bar')
       expect(subject.parsed['answer']).to eq('42')
@@ -53,7 +53,7 @@ describe OAuth2::Response do
       headers = {'Content-Type' => 'application/json'}
       body = MultiJson.encode(:foo => 'bar', :answer => 42)
       response = double('response', :headers => headers, :body => body)
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.parsed.keys.size).to eq(2)
       expect(subject.parsed['foo']).to eq('bar')
       expect(subject.parsed['answer']).to eq(42)
@@ -69,7 +69,7 @@ describe OAuth2::Response do
       expect(MultiJson).not_to receive(:load)
       expect(Rack::Utils).not_to receive(:parse_query)
 
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.parsed).to be_nil
     end
   end


### PR DESCRIPTION
This global inclusion of the OAuth2 recently introduced big issues in version 1.4.5 of OAuth2, fixed in #537.

This should cause big amount of test failures, but everything is green when it's merged with #537.
