### PR TITLE
Remove reliance on globally included OAuth2 in tests for version 2.0

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -31,11 +31,6 @@ Faraday.default_adapter = :test
 DEBUG = ENV['DEBUG'] == 'true'
 require 'byebug' if DEBUG && RUBY_VERSION >= '2.6'
 
-# This is dangerous - HERE BE DRAGONS.
-# It allows us to refer to classes without the namespace, but at what cost?!?
-# TODO: Refactor to use explicit references everywhere
-include OAuth2
-
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe AccessToken do
+RSpec.describe OAuth2::AccessToken do
   subject { described_class.new(client, token) }
 
   let(:token) { 'monkey' }
   let(:refresh_body) { MultiJson.encode(access_token: 'refreshed_foo', expires_in: 600, refresh_token: 'refresh_bar') }
   let(:client) do
-    Client.new('abc', 'def', site: 'https://api.example.com') do |builder|
+    OAuth2::Client.new('abc', 'def', site: 'https://api.example.com') do |builder|
       builder.request :url_encoded
       builder.adapter :test do |stub|
         VERBS.each do |verb|

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-RSpec.describe MACToken do
+RSpec.describe OAuth2::MACToken do
   subject { described_class.new(client, token, 'abc123', kid: kid) }
 
   let(:kid) { 'this-token' }
   let(:token) { 'monkey' }
   let(:client) do
-    Client.new('abc', 'def', site: 'https://api.example.com') do |builder|
+    OAuth2::Client.new('abc', 'def', site: 'https://api.example.com') do |builder|
       builder.request :url_encoded
       builder.adapter :test do |stub|
         VERBS.each do |verb|
@@ -112,7 +112,7 @@ RSpec.describe MACToken do
     subject { described_class.from_access_token(access_token, 'hello') }
 
     let(:access_token) do
-      AccessToken.new(
+      OAuth2::AccessToken.new(
         client, token,
         expires_at: 1,
         expires_in: 1,

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe OAuth2::Response do
       headers = {'Content-Type' => 'application/Json'}
       body = MultiJson.encode(foo: 'bar', answer: 42)
       response = double('response', headers: headers, body: body)
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.parsed.keys.size).to eq(2)
       expect(subject.parsed['foo']).to eq('bar')
       expect(subject.parsed['answer']).to eq(42)
@@ -140,7 +140,7 @@ RSpec.describe OAuth2::Response do
       headers = {'Content-Type' => 'application/json'}
       body = MultiJson.encode('accessToken' => 'bar', 'MiGever' => 'Ani')
       response = double('response', headers: headers, body: body)
-      subject = Response.new(response)
+      subject = described_class.new(response)
       expect(subject.parsed.keys.size).to eq(2)
       expect(subject.parsed['access_token']).to eq('bar')
       expect(subject.parsed['mi_gever']).to eq('Ani')

--- a/spec/oauth2/snaky_hash_spec.rb
+++ b/spec/oauth2/snaky_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SnakyHash do
+RSpec.describe OAuth2::SnakyHash do
   subject { described_class.new }
 
   describe '.build' do

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe OAuth2::Strategy::Assertion do
           end
 
           it 'returns an AccessToken' do
-            expect(access_token).to be_an(AccessToken)
+            expect(access_token).to be_an(OAuth2::AccessToken)
           end
 
           it 'returns AccessToken with same Client' do


### PR DESCRIPTION
This global inclusion of the OAuth2 recently introduced big issues in version 1.4.5 of OAuth2, fixed in #537.

This is basically a version of #538 but against master instead of 1-4-stable.
