### PR TITLE
Pend specs on Ruby 1.9 that fail on OpenSSL changes

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency 'backports', '~> 3.11'
   spec.add_development_dependency 'bundler', '>= 1.16'
-  spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rdoc', ['>= 5.0', '< 7']
   spec.add_development_dependency 'rspec', '~> 3.0'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -20,6 +20,7 @@ require 'oauth2'
 require 'addressable/uri'
 require 'rspec'
 require 'rspec/stubbed_env'
+require 'rspec/pending_for'
 require 'silent_stream'
 
 RSpec.configure do |config|

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -24,18 +24,18 @@ describe OAuth2::MACToken do
     end
 
     it 'defaults algorithm to hmac-sha-256' do
-      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       expect(subject.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-256' do
-      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-256')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-1' do
-      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-1')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA1)
     end

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -24,18 +24,18 @@ describe OAuth2::MACToken do
     end
 
     it 'defaults algorithm to hmac-sha-256' do
-      pending_for(:engine => "ruby", :versions => "1.9")
+      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       expect(subject.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-256' do
-      pending_for(:engine => "ruby", :versions => "1.9")
+      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-256')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-1' do
-      pending_for(:engine => "ruby", :versions => "1.9")
+      pending_for(:engine => "ruby", :versions => "1.9", :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-1')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA1)
     end

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -24,18 +24,18 @@ describe OAuth2::MACToken do
     end
 
     it 'defaults algorithm to hmac-sha-256' do
-      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9.3', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       expect(subject.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-256' do
-      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9.3', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-256')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-1' do
-      pending_for(:engine => 'ruby', :versions => '1.9', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
+      pending_for(:engine => 'ruby', :versions => '1.9.3', :reason => "Ruby 1.9's OpenSSL uses instance of OpenSSL::Digest")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-1')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA1)
     end

--- a/spec/oauth2/mac_token_spec.rb
+++ b/spec/oauth2/mac_token_spec.rb
@@ -24,15 +24,18 @@ describe OAuth2::MACToken do
     end
 
     it 'defaults algorithm to hmac-sha-256' do
+      pending_for(:engine => "ruby", :versions => "1.9")
       expect(subject.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-256' do
+      pending_for(:engine => "ruby", :versions => "1.9")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-256')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA256)
     end
 
     it 'handles hmac-sha-1' do
+      pending_for(:engine => "ruby", :versions => "1.9")
       mac = described_class.new(client, token, 'abc123', :algorithm => 'hmac-sha-1')
       expect(mac.algorithm).to be_instance_of(OpenSSL::Digest::SHA1)
     end


### PR DESCRIPTION
OpenSSL has changed significantly between Ruby 1.9 (when it was a standard library) and now, when it is stand alone ruby gem.