### PR TITLE
Raise an error if Location header not present for redirection

### DIFF
--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -116,7 +116,13 @@ module OAuth2
           verb = :get
           opts.delete(:body)
         end
-        request(verb, response.headers['location'], opts)
+        location = response.headers['location']
+        if location
+          request(verb, location, opts)
+        else
+          error = Error.new(response)
+          raise(error, "Got #{response.status} status code, but no Location header was present")
+        end
       when 200..299, 300..399
         # on non-redirecting 3xx statuses, just return the response
         response

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe OAuth2::Client do
         stub.get('/unauthorized')        { |_env| [401, {'Content-Type' => 'application/json'}, MultiJson.encode(error: error_value, error_description: error_description_value)] }
         stub.get('/conflict')            { |_env| [409, {'Content-Type' => 'text/plain'}, 'not authorized'] }
         stub.get('/redirect')            { |_env| [302, {'Content-Type' => 'text/plain', 'location' => '/success'}, ''] }
+        stub.get('/redirect_no_loc')     { |_env| [302, {'Content-Type' => 'text/plain'}, ''] }
         stub.post('/redirect')           { |_env| [303, {'Content-Type' => 'text/plain', 'location' => '/reflect'}, ''] }
         stub.get('/error')               { |_env| [500, {'Content-Type' => 'text/plain'}, 'unknown error'] }
         stub.get('/empty_get')           { |_env| [204, {}, nil] }
@@ -361,6 +362,10 @@ RSpec.describe OAuth2::Client do
       response = subject.request(:post, '/redirect', body: 'foo=bar')
       expect(response.body).to be_empty
       expect(response.status).to eq(200)
+    end
+
+    it 'raises an error if a redirect has no Location header' do
+      expect { subject.request(:get, '/redirect_no_loc') }.to raise_error(OAuth2::Error, 'Got 302 status code, but no Location header was present')
     end
 
     it 'obeys the :max_redirects option' do


### PR DESCRIPTION
We saw this when trying to use Azure Government Cloud. When
`https://graph.microsoft.com/v1.0/me` was used instead of
`https://graph.microsoft.us/v1.0/me`, Azure returned a 302 response with
no `Location` header. As a result, the OAuth2 client would mysteriously
try to make a GET request to `http:/`, which would fail in Net::HTTP:

```
NoMethodError (undefined method `include?' for nil:NilClass):
/opt/gitlab/embedded/lib/ruby/2.7.0/net/http.rb:1650:in `addr_port'
/opt/gitlab/embedded/lib/ruby/2.7.0/net/http.rb:1585:in `begin_transport'
/opt/gitlab/embedded/lib/ruby/2.7.0/net/http.rb:1518:in `transport_request'
/opt/gitlab/embedded/lib/ruby/2.7.0/net/http.rb:1492:in `request'
```