### PR TITLE
skip coverage on non-mri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
     gem 'rubocop-rake', platform: :mri
     gem 'rubocop-rspec', platform: :mri
 
-    gem 'coveralls'
+    gem 'coveralls', platform: :mri
     gem 'simplecov', platform: :mri
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,7 +10,7 @@ ruby_version = Gem::Version.new(RUBY_VERSION)
 # No need to get coverage for older versions of Ruby
 coverable_version = Gem::Version.new('2.7')
 
-if ruby_version >= coverable_version
+if ruby_version >= coverable_version && RUBY_ENGINE == "ruby"
   require 'simplecov'
   require 'coveralls'
   SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new([


### PR DESCRIPTION
we should either enable ```simplecov``` gem on non-mri rubies or skip it

fixes failures on travis
```
LoadError:
  cannot load such file -- simplecov
```