### PR TITLE
missing require oauth2/version.rb

### DIFF
--- a/lib/oauth2.rb
+++ b/lib/oauth2.rb
@@ -5,6 +5,7 @@ require 'cgi'
 require 'time'
 
 # includes gem files
+require 'oauth2/version'
 require 'oauth2/error'
 require 'oauth2/snaky_hash'
 require 'oauth2/authenticator'


### PR DESCRIPTION
I think it should be required explicitely

fixes
```
Failure/Error:
  RSpec.describe OAuth2::Version do
....
NameError:
  uninitialized constant OAuth2::Version
```