### PR TITLE
feat: add support parsing for application/problem+json

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -128,6 +128,6 @@ OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'appl
   MultiXml.parse(body) rescue body # rubocop:disable Style/RescueModifier
 end
 
-OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json']) do |body|
+OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json', 'application/problem+json']) do |body|
   MultiJson.decode(body) rescue body # rubocop:disable Style/RescueModifier
 end

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -122,6 +122,16 @@ RSpec.describe OAuth2::Response do
       expect(subject.parsed['answer']).to eq(42)
     end
 
+    it 'parses application/problem+json body' do
+      headers = {'Content-Type' => 'application/problem+json'}
+      body = MultiJson.encode(type: 'https://tools.ietf.org/html/rfc7231#section-6.5.4', title: 'Not Found')
+      response = double('response', headers: headers, body: body)
+      subject = described_class.new(response)
+      expect(subject.parsed.keys.size).to eq(2)
+      expect(subject.parsed['type']).to eq('https://tools.ietf.org/html/rfc7231#section-6.5.4')
+      expect(subject.parsed['title']).to eq('Not Found')
+    end
+
     it "doesn't try to parse other content-types" do
       headers = {'Content-Type' => 'text/html'}
       body = '<!DOCTYPE html><html><head></head><body></body></html>'


### PR DESCRIPTION
[application/problem+json](https://datatracker.ietf.org/doc/html/rfc7807) is an extension of the application/json format
to describe errors in an standardized way.