### PR TITLE
Don't set auth params if they are nil

### DIFF
--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -45,13 +45,18 @@ module OAuth2
     # Adds client_id and client_secret request parameters if they are not
     # already set.
     def apply_params_auth(params)
-      {'client_id' => id, 'client_secret' => secret}.merge(params)
+      result = {}
+      result['client_id'] = id unless id.nil?
+      result['client_secret'] = secret unless secret.nil?
+      result.merge(params)
     end
 
     # When using schemes that don't require the client_secret to be passed i.e TLS Client Auth,
     # we don't want to send the secret
     def apply_client_id(params)
-      {'client_id' => id}.merge(params)
+      result = {}
+      result['client_id'] = id unless id.nil?
+      result.merge(params)
     end
 
     # Adds an `Authorization` header with Basic Auth credentials if and only if

--- a/spec/oauth2/authenticator_spec.rb
+++ b/spec/oauth2/authenticator_spec.rb
@@ -39,6 +39,14 @@ RSpec.describe OAuth2::Authenticator do
         )
       end
 
+      context 'passing nil secret' do
+        let(:client_secret) { nil }
+        it 'does not set nil client_secret' do
+          output = subject.apply({})
+          expect(output).to eq('client_id' => 'foo')
+        end
+      end
+
       context 'using tls client authentication' do
         let(:mode) { :tls_client_auth }
 


### PR DESCRIPTION
Some oauth providers don't like it if you pass an empty client_secret. According to the spec it may be omitted if it's empty: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1