### PR TITLE
Fix spec for support faraday 2

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -6,7 +6,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 2.0']
+  spec.add_dependency 'faraday', ['>= 1.0', '< 3.0']
   spec.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'

--- a/spec/examples/google_spec.rb
+++ b/spec/examples/google_spec.rb
@@ -72,10 +72,11 @@ RSpec.describe 'using OAuth2 with Google' do
     let(:encoding_options) { {key: key, algorithm: algorithm} }
 
     before do
-      client.connection.build do |builder|
+      client.connection = Faraday.new(client.site, client.options[:connection_opts]) do |builder|
+        builder.request :url_encoded
         builder.adapter :test do |stub|
           stub.post('https://accounts.google.com/o/oauth2/token') do |token_request|
-            @request_body = token_request.body
+            @request_body = Rack::Utils.parse_nested_query(token_request.body).transform_keys(&:to_sym)
 
             [
               200,

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe OAuth2::Client do
   context 'with SSL options' do
     subject do
       cli = described_class.new('abc', 'def', site: 'https://api.example.com', ssl: {ca_file: 'foo.pem'})
-      cli.connection.build do |b|
+      cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
         b.adapter :test
       end
       cli

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe OAuth2::Strategy::Assertion do
 
   let(:client) do
     cli = OAuth2::Client.new('abc', 'def', site: 'http://api.example.com', auth_scheme: auth_scheme)
-    cli.connection.build do |b|
+    cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
+      b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/oauth/token') do |token_request|
-          @request_body = token_request.body
+          @request_body = Rack::Utils.parse_nested_query(token_request.body).transform_keys(&:to_sym)
 
           case @response_format
           when 'formencoded'
@@ -159,22 +160,22 @@ RSpec.describe OAuth2::Strategy::Assertion do
         it 'includes assertion and grant_type, along with the client parameters' do
           subject.get_token(claims, algorithm: algorithm, key: key)
           expect(@request_body).not_to be_nil
-          expect(@request_body.keys).to match_array([:assertion, :grant_type, 'client_id', 'client_secret'])
+          expect(@request_body.keys).to match_array(%i[assertion grant_type client_id client_secret])
           expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
           expect(@request_body[:assertion]).to be_a(String)
-          expect(@request_body['client_id']).to eq('abc')
-          expect(@request_body['client_secret']).to eq('def')
+          expect(@request_body[:client_id]).to eq('abc')
+          expect(@request_body[:client_secret]).to eq('def')
         end
 
         it 'includes other params via request_options' do
           subject.get_token(claims, {algorithm: algorithm, key: key}, scope: 'dover sole')
           expect(@request_body).not_to be_nil
-          expect(@request_body.keys).to match_array([:assertion, :grant_type, :scope, 'client_id', 'client_secret'])
+          expect(@request_body.keys).to match_array(%i[assertion grant_type scope client_id client_secret])
           expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
           expect(@request_body[:assertion]).to be_a(String)
           expect(@request_body[:scope]).to eq('dover sole')
-          expect(@request_body['client_id']).to eq('abc')
-          expect(@request_body['client_secret']).to eq('def')
+          expect(@request_body[:client_id]).to eq('abc')
+          expect(@request_body[:client_secret]).to eq('def')
         end
       end
 

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe OAuth2::Strategy::Password do
 
   let(:client) do
     cli = OAuth2::Client.new('abc', 'def', site: 'http://api.example.com')
-    cli.connection.build do |b|
+    cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
+      b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/oauth/token') do |_env|
           case @mode


### PR DESCRIPTION
Fixed specs with reference to the upgrade guide to support Faraday 2.0.
Fixed `Faraday::Builder#build` cannot be used.


https://github.com/lostisland/faraday/blob/main/UPGRADING.md#others


```
Faraday::Builder#build method is not exposed through Faraday::Connection anymore and does not reset the handlers if called multiple times. This method should be used internally only.
```

Related to the following issues.
https://github.com/oauth-xx/oauth2/pull/558
https://github.com/oauth-xx/oauth2/issues/559
