### PR TITLE
Remove development_dependency wwtd

### DIFF
--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -47,5 +47,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-pending_for'
   spec.add_development_dependency 'rspec-stubbed_env'
   spec.add_development_dependency 'silent_stream'
-  spec.add_development_dependency 'wwtd'
 end


### PR DESCRIPTION
Last use of wwtd was removed in ebe95171c3d34b9f8f4a4dfdca2e5094efc2dee.