### PR TITLE
Support Faraday 2.x on 1-4-stable branch, for subsequent 1.x release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'faraday', ['>= 0.8', '< 2.0'], :platforms => [:jruby_18, :ruby_18]
+gem 'faraday', ['>= 0.8', '< 3.0'], :platforms => [:jruby_18, :ruby_18]
 gem 'jwt'
 gem 'overcommit'
 gem 'rake'

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -59,15 +59,12 @@ module OAuth2
 
     # The Faraday connection object
     def connection
-      @connection ||= begin
-        conn = Faraday.new(site, options[:connection_opts])
-        if options[:connection_build]
-          conn.build do |b|
-            options[:connection_build].call(b)
+      @connection ||=
+        Faraday.new(site, options[:connection_opts]) do |builder|
+          if options[:connection_build]
+            options[:connection_build].call(builder)
           end
         end
-        conn
-      end
     end
 
     # The authorize endpoint URL of the OAuth2 provider

--- a/oauth2.gemspec
+++ b/oauth2.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'oauth2/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.8', '< 2.0']
+  spec.add_dependency 'faraday', ['>= 0.8', '< 3.0']
   spec.add_dependency 'jwt', ['>= 1.0', '< 3.0']
   spec.add_dependency 'multi_json', '~> 1.3'
   spec.add_dependency 'multi_xml', '~> 0.5'

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -46,7 +46,7 @@ describe OAuth2::Client do
     it 'is able to pass a block to configure the connection' do
       connection = double('connection')
       builder = double('builder')
-      allow(connection).to receive(:build).and_yield(builder)
+      allow(Faraday).to receive(:new).and_yield(builder)
       allow(Faraday::Connection).to receive(:new).and_return(connection)
 
       expect(builder).to receive(:adapter).with(:test)

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -517,7 +517,7 @@ describe OAuth2::Client do
   context 'with SSL options' do
     subject do
       cli = described_class.new('abc', 'def', :site => 'https://api.example.com', :ssl => {:ca_file => 'foo.pem'})
-      cli.connection.build do |b|
+      cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
         b.adapter :test
       end
       cli

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -3,7 +3,8 @@ describe OAuth2::Strategy::Assertion do
 
   let(:client) do
     cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
-    cli.connection.build do |b|
+    cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
+      b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/oauth/token') do |env|
           case @mode

--- a/spec/oauth2/strategy/password_spec.rb
+++ b/spec/oauth2/strategy/password_spec.rb
@@ -3,7 +3,8 @@ describe OAuth2::Strategy::Password do
 
   let(:client) do
     cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
-    cli.connection.build do |b|
+    cli.connection = Faraday.new(cli.site, cli.options[:connection_opts]) do |b|
+      b.request :url_encoded
       b.adapter :test do |stub|
         stub.post('/oauth/token') do |env|
           case @mode


### PR DESCRIPTION
For subsequent 1.x release supporting faraday 2.x -- gemspec is unchanged as to how old a faraday it allows, all the way back to 0.8 as per previous 1.x release. 

Backported enough from master to get tests passing on both/either faraday 1.x AND 2.x. 

I have confirmed locally that `bundle exec rspec` passes using both Faraday 1.9.3 and Faraday 2.2.0, by making local uncommitted edits the Gemfile to force both. 

CI will of course only run with one version of Faraday. I'm not sure if it will actually be 1.x or 2.x -- see https://github.com/oauth-xx/oauth2/pull/561#issuecomment-1041714757

But this should make it possible to do a 1.4 release that allows and works with Faraday 2.x? 