### PR TITLE
use SHA256 digest

### DIFF
--- a/lib/oauth2/mac_token.rb
+++ b/lib/oauth2/mac_token.rb
@@ -62,7 +62,7 @@ module OAuth2
     # @param [String] url the HTTP URL path of the request
     def header(verb, url)
       timestamp = Time.now.utc.to_i
-      nonce = Digest::MD5.hexdigest([timestamp, SecureRandom.hex].join(':'))
+      nonce = Digest::SHA256.hexdigest([timestamp, SecureRandom.hex].join(':'))
 
       uri = URI.parse(url)
 


### PR DESCRIPTION
This patch is for the 1.4 stable branch because it is used in production.

It updates usage of MD5 to SHA256 as a FIPS approved algorythm.

I understand that MD5 usage is fine in general for this use case. The
problem is that on a FIPS configured system, trying to generate MD5 with
openssl fails.

To enable usage on such systems, any other digest algorythm can be used.
SHA256 seems to be the default choice in the community. For example Rails 7.