### PR TITLE
Backport extract_access_token option to OAuth2::Client

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module OAuth2
-  class AccessToken
+  class AccessToken # rubocop:disable Metrics/ClassLength
     attr_reader :client, :token, :expires_in, :expires_at, :expires_latency, :params
     attr_accessor :options, :refresh_token, :response
 
@@ -23,6 +23,10 @@ module OAuth2
       # @return [AccessToken] the initialized AccessToken
       def from_kvform(client, kvform)
         from_hash(client, Rack::Utils.parse_query(kvform))
+      end
+
+      def contains_token?(hash)
+        hash.key?('access_token') || hash.key?('id_token') || hash.key?('token')
       end
     end
 
@@ -89,7 +93,7 @@ module OAuth2
 
       params[:grant_type] = 'refresh_token'
       params[:refresh_token] = refresh_token
-      new_token = @client.get_token(params, access_token_opts, access_token_class)
+      new_token = @client.get_token(params, access_token_opts, access_token_class: access_token_class)
       new_token.options = options
       new_token.refresh_token = refresh_token unless new_token.refresh_token
       new_token

--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -129,9 +129,7 @@ OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'appl
 end
 
 OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json', 'application/problem+json']) do |body|
-  if body.respond_to?(:force_encoding)
-    body = body.dup.force_encoding(::Encoding::ASCII_8BIT)
-  end
+  body = body.dup.force_encoding(::Encoding::ASCII_8BIT) if body.respond_to?(:force_encoding)
 
   ::JSON.parse(body)
 end


### PR DESCRIPTION
This pulls in the changes in #518 from the `1-4-stable` and deprecates
the `extract_access_token` option in favor of the
`access_token_class`.

We move the `access_token_class` as a keyword argument to `get_token`
to avoid having to do dynamic argument checking due to the legacy
`extract_access_token` argument.

`access_token_class` is now responsible for implementing two methods:

- `.from_hash`
- `.contains_token?`

Closes #582