### PR TITLE
Fix specs failing in Ruby 3.0+

### DIFF
--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -502,10 +502,11 @@ RSpec.describe OAuth2::Client do
     end
 
     describe 'with custom access_token_class option' do
+      let(:payload) { {'custom_token' => 'the-token'} }
       let(:client) do
         stubbed_client do |stub|
           stub.post('/oauth/token') do
-            [200, {'Content-Type' => 'application/json'}, JSON.dump('custom_token' => 'the-token')]
+            [200, {'Content-Type' => 'application/json'}, JSON.dump(payload)]
           end
         end
       end
@@ -526,6 +527,15 @@ RSpec.describe OAuth2::Client do
 
       it 'returns the parsed :custom_token from body' do
         client.get_token({}, {}, nil, access_token_class: CustomAccessToken)
+      end
+
+      context 'when the :raise_errors flag is set to true' do
+        let(:options) { {raise_errors: true} }
+        let(:payload) { {} }
+
+        it 'raise an error' do
+          expect { client.get_token({}, {}, nil, access_token_class: CustomAccessToken) }.to raise_error(OAuth2::Error)
+        end
       end
     end
 

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -525,7 +525,7 @@ RSpec.describe OAuth2::Client do
       end
 
       it 'returns the parsed :custom_token from body' do
-        client.get_token({}, {}, {access_token_class: CustomAccessToken})
+        client.get_token({}, {}, nil, access_token_class: CustomAccessToken)
       end
     end
 
@@ -558,7 +558,7 @@ RSpec.describe OAuth2::Client do
           [200, {'Content-Type' => 'application/json'}, JSON.dump('access_token' => 'the-token')]
         end
       end
-      client.get_token('arbitrary' => 'parameter')
+      client.get_token({'arbitrary' => 'parameter'}) # rubocop:disable Style/BracesAroundHashParameters
     end
 
     context 'when token_method is set to post_with_query_string' do
@@ -568,7 +568,7 @@ RSpec.describe OAuth2::Client do
             [200, {'Content-Type' => 'application/json'}, JSON.dump('access_token' => 'the-token')]
           end
         end
-        client.get_token('state' => 'abc123')
+        client.get_token({'state' => 'abc123'}) # rubocop:disable Style/BracesAroundHashParameters
       end
     end
 

--- a/spec/oauth2/version_spec.rb
+++ b/spec/oauth2/version_spec.rb
@@ -20,4 +20,28 @@ RSpec.describe OAuth2::Version do
   it 'is pre-release' do
     expect(Gem::Version.new(described_class).prerelease?).to be(true)
   end
+
+  it 'major version is an integer' do
+    expect(described_class.major).to be_a(Integer)
+  end
+
+  it 'minor version is an integer' do
+    expect(described_class.minor).to be_a(Integer)
+  end
+
+  it 'patch version is an integer' do
+    expect(described_class.patch).to be_a(Integer)
+  end
+
+  it 'pre version is an String' do
+    expect(described_class.pre).to be_a(String)
+  end
+
+  it 'returns a Hash' do
+    expect(described_class.to_h.keys).to match_array(%i[major minor patch pre])
+  end
+
+  it 'returns an Array' do
+    expect(described_class.to_a).to be_a(Array)
+  end
 end


### PR DESCRIPTION
We need to be mindful of kwargs and args.