### PR TITLE
Fix code coverage for version spec

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -16,6 +16,7 @@ if RUN_COVERAGE
     enable_coverage :branch
     primary_coverage :branch
     add_filter 'spec'
+    add_filter 'lib/oauth2/version.rb'
     track_files '**/*.rb'
 
     if ALL_FORMATTERS

--- a/spec/oauth2/version_spec.rb
+++ b/spec/oauth2/version_spec.rb
@@ -17,10 +17,6 @@ RSpec.describe OAuth2::Version do
     expect(Gem::Version.new(described_class) > Gem::Version.new('0.1.0')).to be(true)
   end
 
-  it 'is pre-release' do
-    expect(Gem::Version.new(described_class).prerelease?).to be(true)
-  end
-
   it 'major version is an integer' do
     expect(described_class.major).to be_a(Integer)
   end
@@ -31,10 +27,6 @@ RSpec.describe OAuth2::Version do
 
   it 'patch version is an integer' do
     expect(described_class.patch).to be_a(Integer)
-  end
-
-  it 'pre version is an String' do
-    expect(described_class.pre).to be_a(String)
   end
 
   it 'returns a Hash' do


### PR DESCRIPTION
As explained in https://github.com/simplecov-ruby/simplecov/issues/557, since `oauth2.gemspec` calls `require 'oauth2/version.rb`, SimpleCov runs after that file is loaded. We can just exclude it from the code coverage metrics.

In addition, we can drop version specs that fail on a released tag.