### PR TITLE
Use a keyword argument for access_token_class in AccessToken#refresh!

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -88,7 +88,7 @@ module OAuth2
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh(params = {}, access_token_opts = {}, access_token_class = self.class)
+    def refresh(params = {}, access_token_opts = {}, access_token_class: self.class)
       raise('A refresh_token is not available') unless refresh_token
 
       params[:grant_type] = 'refresh_token'


### PR DESCRIPTION
This is to be consistent with `OAuth2::Client#get_token`.