### PR TITLE
Move access_token_class parameter into Client constructor

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -88,12 +88,12 @@ module OAuth2
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh(params = {}, access_token_opts = {}, access_token_class: self.class)
+    def refresh(params = {}, access_token_opts = {})
       raise('A refresh_token is not available') unless refresh_token
 
       params[:grant_type] = 'refresh_token'
       params[:refresh_token] = refresh_token
-      new_token = @client.get_token(params, access_token_opts, access_token_class: access_token_class)
+      new_token = @client.get_token(params, access_token_opts)
       new_token.options = options
       new_token.refresh_token = refresh_token unless new_token.refresh_token
       new_token

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -544,11 +544,13 @@ RSpec.describe OAuth2::Client do
     end
 
     describe 'with custom access_token_class option' do
+      let(:options) { {access_token_class: CustomAccessToken} }
       let(:payload) { {'custom_token' => 'the-token'} }
+      let(:content_type) { 'application/json' }
       let(:client) do
-        stubbed_client do |stub|
+        stubbed_client(options) do |stub|
           stub.post('/oauth/token') do
-            [200, {'Content-Type' => 'application/json'}, JSON.dump(payload)]
+            [200, {'Content-Type' => content_type}, JSON.dump(payload)]
           end
         end
       end
@@ -568,15 +570,15 @@ RSpec.describe OAuth2::Client do
       end
 
       it 'returns the parsed :custom_token from body' do
-        client.get_token({}, {}, nil, access_token_class: CustomAccessToken)
+        client.get_token({})
       end
 
       context 'when the :raise_errors flag is set to true' do
-        let(:options) { {raise_errors: true} }
+        let(:options) { {access_token_class: CustomAccessToken, raise_errors: true} }
         let(:payload) { {} }
 
         it 'raise an error' do
-          expect { client.get_token({}, {}, nil, access_token_class: CustomAccessToken) }.to raise_error(OAuth2::Error)
+          expect { client.get_token({}) }.to raise_error(OAuth2::Error)
         end
       end
 


### PR DESCRIPTION
Mixing positional and keyword arguments raises deprecation warnings in
Ruby 2.7. It's cleaner to make access_token_class an option at init time.

Closes #605