### PR TITLE
Avoid reparsing a response body

### DIFF
--- a/lib/oauth2/response.rb
+++ b/lib/oauth2/response.rb
@@ -125,10 +125,14 @@ module OAuth2
 end
 
 OAuth2::Response.register_parser(:xml, ['text/xml', 'application/rss+xml', 'application/rdf+xml', 'application/atom+xml', 'application/xml']) do |body|
+  next body unless body.respond_to?(:to_str)
+
   MultiXml.parse(body)
 end
 
 OAuth2::Response.register_parser(:json, ['application/json', 'text/javascript', 'application/hal+json', 'application/vnd.collection+json', 'application/vnd.api+json', 'application/problem+json']) do |body|
+  next body unless body.respond_to?(:to_str)
+
   body = body.dup.force_encoding(::Encoding::ASCII_8BIT) if body.respond_to?(:force_encoding)
 
   ::JSON.parse(body)

--- a/spec/oauth2/response_spec.rb
+++ b/spec/oauth2/response_spec.rb
@@ -208,6 +208,19 @@ RSpec.describe OAuth2::Response do
       expect(subject.parsed).to be_nil
     end
 
+    it "doesn't parse bodies which have previously been parsed" do
+      headers = {'Content-Type' => 'application/json'}
+      body = {foo: 'bar', answer: 42, krill: nil, zero: 0, malign: false, shine: true}
+
+      response = double('response', headers: headers, body: body)
+
+      expect(JSON).not_to receive(:parse)
+      expect(Rack::Utils).not_to receive(:parse_query)
+
+      subject = described_class.new(response)
+      expect(subject.parsed.keys.size).to eq(6)
+    end
+
     it 'snakecases json keys when parsing' do
       headers = {'Content-Type' => 'application/json'}
       body = JSON.dump('accessToken' => 'bar', 'MiGever' => 'Ani')


### PR DESCRIPTION
The oauth2 v2 release [removed the rescue catch-all](https://github.com/oauth-xx/oauth2/pull/576) when parsing failed. This exposed a possible issue where someone overriding or extending the Faraday connection middleware stack may parse response bodies ahead of the packaged middleware in this library. In that case, this library attempts to re-parse an already-parsed body, thereby throwing various exceptions (`TypeError: no implicit conversion of Hash into String`, for example).

Faraday doesn't provide a standard interface to determine whether or not a response has already been parsed. Instead, it relies on middleware developers performing cursory checks of the object type (generally, if the [body responds to `to_str`](https://github.com/lostisland/faraday/blob/fcb2003178dc362888d5ccf16bfb776a4aa16f46/lib/faraday/response/json.rb#L33-L36) then it's _probably_ a string, and it's _probably_ not yet parsed).

This change adds that cursory check to make sure the response body is still string-like before attempting to parse it into Ruby objects.