### PR TITLE
🗑️ Deprecate extract_access_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format (since v2) is based on [Keep a Changelog v1](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning v2](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-06-27
+### Added
+- [#611](https://github.com/oauth-xx/oauth2/pull/611) - Proper deprecation warnings for `extract_access_token` argument (@pboling)
+### Fixed
+- [#608](https://github.com/oauth-xx/oauth2/pull/608) - Wrap `Faraday::TimeoutError` in `OAuth2::TimeoutError` (@nbibler)
+
 ## [2.0.2] - 2022-06-24
 ### Fixed
 - [#604](https://github.com/oauth-xx/oauth2/pull/604) - Wrap `Faraday::TimeoutError` in `OAuth2::TimeoutError` (@stanhu)
@@ -221,7 +227,7 @@ and this project adheres to [Semantic Versioning v2](https://semver.org/spec/v2.
 
 ## [0.0.4] + [0.0.3] + [0.0.2] + [0.0.1] - 2010-04-22
 
-[Unreleased]: https://github.com/oauth-xx/oauth2/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/oauth-xx/oauth2/compare/v2.0.3...HEAD
 [0.0.1]: https://github.com/oauth-xx/oauth2/compare/311d9f4...v0.0.1
 [0.0.2]: https://github.com/oauth-xx/oauth2/compare/v0.0.1...v0.0.2
 [0.0.3]: https://github.com/oauth-xx/oauth2/compare/v0.0.2...v0.0.3
@@ -259,4 +265,6 @@ and this project adheres to [Semantic Versioning v2](https://semver.org/spec/v2.
 [1.4.9]: https://github.com/oauth-xx/oauth2/compare/v1.4.8...v1.4.9
 [2.0.0]: https://github.com/oauth-xx/oauth2/compare/v1.4.9...v2.0.0
 [2.0.1]: https://github.com/oauth-xx/oauth2/compare/v2.0.0...v2.0.1
+[2.0.2]: https://github.com/oauth-xx/oauth2/compare/v2.0.1...v2.0.2
+[2.0.3]: https://github.com/oauth-xx/oauth2/compare/v2.0.2...v2.0.3
 [gemfiles/readme]: gemfiles/README.md

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -41,7 +41,7 @@ module OAuth2
       @secret = client_secret
       @site = opts.delete(:site)
       ssl = opts.delete(:ssl)
-
+      warn('OAuth2::Client#initialize argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class`') if opts[:extract_access_token]
       @options = {
         authorize_url: 'oauth/authorize',
         token_url: 'oauth/token',
@@ -150,7 +150,9 @@ module OAuth2
     # @param access_token_opts [Hash] access token options, to pass to the AccessToken object
     # @param extract_access_token [Proc] proc that extracts the access token from the response (DEPRECATED)
     # @return [AccessToken] the initialized AccessToken
-    def get_token(params, access_token_opts = {}, extract_access_token = options[:extract_access_token])
+    def get_token(params, access_token_opts = {}, extract_access_token = nil)
+      warn('OAuth2::Client#get_token argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class` on #initialize') if extract_access_token
+      extract_access_token ||= options[:extract_access_token]
       params = params.map do |key, value|
         if RESERVED_PARAM_KEYS.include?(key)
           [key.to_sym, value]

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -41,7 +41,7 @@ module OAuth2
       @secret = client_secret
       @site = opts.delete(:site)
       ssl = opts.delete(:ssl)
-      warn('OAuth2::Client#initialize argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class`') if opts[:extract_access_token]
+      warn('OAuth2::Client#initialize argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class`.') if opts[:extract_access_token]
       @options = {
         authorize_url: 'oauth/authorize',
         token_url: 'oauth/token',
@@ -151,7 +151,7 @@ module OAuth2
     # @param extract_access_token [Proc] proc that extracts the access token from the response (DEPRECATED)
     # @return [AccessToken] the initialized AccessToken
     def get_token(params, access_token_opts = {}, extract_access_token = nil)
-      warn('OAuth2::Client#get_token argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class` on #initialize') if extract_access_token
+      warn('OAuth2::Client#get_token argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class` on #initialize.') if extract_access_token
       extract_access_token ||= options[:extract_access_token]
       params = params.map do |key, value|
         if RESERVED_PARAM_KEYS.include?(key)

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -643,6 +643,44 @@ RSpec.describe OAuth2::Client do
         expect(token).to be_a OAuth2::AccessToken
         expect(token.token).to eq('the-token')
       end
+
+      context 'with deprecation' do
+        subject(:printed) do
+          capture(:stderr) do
+            client.get_token({})
+          end
+        end
+
+        it 'warns on STDERR' do
+          msg = glo <<-MSG.lstrip
+            OAuth2::Client#initialize argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class`.
+          MSG
+          expect(printed).to eq(msg)
+        end
+
+        context 'on request' do
+          subject(:printed) do
+            capture(:stderr) do
+              client.get_token({}, {}, extract_access_token)
+            end
+          end
+
+          let(:client) do
+            stubbed_client do |stub|
+              stub.post('/oauth/token') do
+                [200, {'Content-Type' => 'application/json'}, JSON.dump('data' => {'access_token' => 'the-token'})]
+              end
+            end
+          end
+
+          it 'warns on STDERR' do
+            msg = <<-MSG.lstrip
+              OAuth2::Client#get_token argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class` on #initialize.
+            MSG
+            expect(printed).to eq(msg)
+          end
+        end
+      end
     end
 
     it 'forwards given token parameters' do

--- a/spec/oauth2/client_spec.rb
+++ b/spec/oauth2/client_spec.rb
@@ -652,7 +652,7 @@ RSpec.describe OAuth2::Client do
         end
 
         it 'warns on STDERR' do
-          msg = glo <<-MSG.lstrip
+          msg = <<-MSG.lstrip
             OAuth2::Client#initialize argument `extract_access_token` will be removed in oauth2 v3. Refactor to use `access_token_class`.
           MSG
           expect(printed).to eq(msg)


### PR DESCRIPTION
🐛 Also fixes bug where provided `extract_access_token` set in `initialize` would not be honored by `get_token`.

Signed-off-by: Peter Boling <peter.boling@gmail.com>