### PR TITLE
2.0.6 uses different token to 2.0.5

### DIFF
--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -18,7 +18,7 @@ module OAuth2
       # @return [AccessToken] the initialized AccessToken
       def from_hash(client, hash)
         fresh = hash.dup
-        supported_keys = fresh.keys & TOKEN_KEY_LOOKUP
+        supported_keys = TOKEN_KEY_LOOKUP & fresh.keys
         key = supported_keys[0]
         # Having too many is sus, and may lead to bugs. Having none is fine (e.g. refresh flow doesn't need a token).
         warn("OAuth2::AccessToken.from_hash: `hash` contained more than one 'token' key (#{supported_keys}); using #{key.inspect}.") if supported_keys.length > 1

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -53,6 +53,28 @@ RSpec.describe OAuth2::AccessToken do
         expect(printed).to eq(msg)
       end
     end
+
+    context 'with keys in a different order to the lookup' do
+      let(:hash) do
+        {
+          :id_token => 'confusing bug here',
+          :access_token => token,
+        }
+      end
+
+      subject(:printed) do
+        capture(:stderr) do
+          target
+        end
+      end
+
+      it 'warns on STDERR and selects the correct key' do
+        msg = <<-MSG.lstrip
+            OAuth2::AccessToken.from_hash: `hash` contained more than one 'token' key ([:access_token, :id_token]); using :access_token.
+        MSG
+        expect(printed).to eq(msg)
+      end
+    end
   end
 
   describe '#initialize' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -55,17 +55,17 @@ RSpec.describe OAuth2::AccessToken do
     end
 
     context 'with keys in a different order to the lookup' do
+      subject(:printed) do
+        capture(:stderr) do
+          target
+        end
+      end
+
       let(:hash) do
         {
           :id_token => 'confusing bug here',
           :access_token => token,
         }
-      end
-
-      subject(:printed) do
-        capture(:stderr) do
-          target
-        end
       end
 
       it 'warns on STDERR and selects the correct key' do

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe OAuth2::AccessToken do
 
       let(:hash) do
         {
-          :id_token => 'confusing bug here',
-          :access_token => token,
+          id_token: 'confusing bug here',
+          access_token: token,
         }
       end
 


### PR DESCRIPTION
I'll start by saying I'm just a user of the gem, I have no idea how the oauth2 process works, we use it with omniauth and cognito for authentication in AWS.

When upgrading to 2.0.6, our logins broke. On investigation, I see the following in the logs:

```
OAuth2::AccessToken.from_hash: `hash` contained more than one 'token' key (["id_token", "access_token"]); using "id_token".
```

Looking at the code changes from #624, the `access_token` was previously being preferred over the `id_token`, so I'm assuming this is the bug.

I've corrected this and added a test to ensure the gem will still function as it did before.