### PR TITLE
Add IETF RFC 7009 Token Revocation

### DIFF
--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -31,8 +31,12 @@
     [130, 3, 52, "Gemspec/DependencyVersion: Dependency version specification is required.", 3163430777],
     [131, 3, 48, "Gemspec/DependencyVersion: Dependency version specification is required.", 425065368]
   ],
-  "spec/oauth2/access_token_spec.rb:3105694173": [
+  "spec/oauth2/access_token_spec.rb:443932125": [
     [3, 1, 34, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/access_token*_spec.rb`.", 1972107547],
+    [392, 142, 40, "Lint/LiteralInInterpolation: Literal interpolation detected.", 4210228387],
+    [400, 142, 40, "Lint/LiteralInInterpolation: Literal interpolation detected.", 4210228387],
+    [606, 142, 20, "Lint/LiteralInInterpolation: Literal interpolation detected.", 304063511],
+    [632, 142, 20, "Lint/LiteralInInterpolation: Literal interpolation detected.", 304063511],
     [781, 13, 25, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 770233088],
     [851, 9, 101, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3022740639],
     [855, 9, 79, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 2507338967]

--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -6,7 +6,7 @@
   "lib/oauth2.rb:4176768025": [
     [38, 11, 7, "ThreadSafety/ClassInstanceVariable: Avoid class instance variables.", 651502127]
   ],
-  "lib/oauth2/access_token.rb:569882683": [
+  "lib/oauth2/access_token.rb:3471244990": [
     [49, 13, 5, "Style/IdenticalConditionalBranches: Move `t_key` out of the conditional.", 183811513],
     [55, 13, 5, "Style/IdenticalConditionalBranches: Move `t_key` out of the conditional.", 183811513]
   ],

--- a/.rubocop_gradual.lock
+++ b/.rubocop_gradual.lock
@@ -3,15 +3,14 @@
     [66, 5, 20, "ThreadSafety/ClassInstanceVariable: Avoid class instance variables.", 2485198147],
     [78, 5, 74, "Style/InvertibleUnlessCondition: Prefer `if Gem.rubygems_version >= Gem::Version.new(\"2.7.0\")` over `unless Gem.rubygems_version < Gem::Version.new(\"2.7.0\")`.", 2453573257]
   ],
-  "lib/oauth2.rb:1956148869": [
-    [35, 5, 21, "ThreadSafety/ClassAndModuleAttributes: Avoid mutating class and module attributes.", 622027168],
+  "lib/oauth2.rb:4176768025": [
     [38, 11, 7, "ThreadSafety/ClassInstanceVariable: Avoid class instance variables.", 651502127]
   ],
-  "lib/oauth2/access_token.rb:2233632404": [
+  "lib/oauth2/access_token.rb:569882683": [
     [49, 13, 5, "Style/IdenticalConditionalBranches: Move `t_key` out of the conditional.", 183811513],
     [55, 13, 5, "Style/IdenticalConditionalBranches: Move `t_key` out of the conditional.", 183811513]
   ],
-  "lib/oauth2/authenticator.rb:3711266135": [
+  "lib/oauth2/authenticator.rb:63639854": [
     [42, 5, 113, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 734523108]
   ],
   "lib/oauth2/filtered_attributes.rb:1202323815": [
@@ -32,11 +31,11 @@
     [130, 3, 52, "Gemspec/DependencyVersion: Dependency version specification is required.", 3163430777],
     [131, 3, 48, "Gemspec/DependencyVersion: Dependency version specification is required.", 425065368]
   ],
-  "spec/oauth2/access_token_spec.rb:3473606468": [
+  "spec/oauth2/access_token_spec.rb:3105694173": [
     [3, 1, 34, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/access_token*_spec.rb`.", 1972107547],
-    [780, 13, 25, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 770233088],
-    [850, 9, 101, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3022740639],
-    [854, 9, 79, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 2507338967]
+    [781, 13, 25, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 770233088],
+    [851, 9, 101, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3022740639],
+    [855, 9, 79, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 2507338967]
   ],
   "spec/oauth2/authenticator_spec.rb:853320290": [
     [3, 1, 36, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/authenticator*_spec.rb`.", 819808017],
@@ -45,26 +44,24 @@
     [69, 15, 38, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1480816240],
     [79, 13, 23, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 2314399065]
   ],
-  "spec/oauth2/client_spec.rb:2085440011": [
+  "spec/oauth2/client_spec.rb:1326196445": [
     [6, 1, 29, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/client*_spec.rb`.", 439549885],
-    [174, 7, 492, "RSpec/NoExpectationExample: No expectation found in this example.", 1272021224],
-    [193, 7, 592, "RSpec/NoExpectationExample: No expectation found in this example.", 3428877205],
-    [206, 15, 20, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 2320605227],
-    [221, 15, 20, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1276531672],
-    [236, 15, 43, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1383956904],
-    [251, 15, 43, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 3376202107],
-    [829, 5, 360, "RSpec/NoExpectationExample: No expectation found in this example.", 536201463],
-    [838, 5, 461, "RSpec/NoExpectationExample: No expectation found in this example.", 3392600621],
-    [849, 5, 340, "RSpec/NoExpectationExample: No expectation found in this example.", 244592251],
-    [894, 63, 2, "RSpec/BeEq: Prefer `be` over `eq`.", 5860785],
-    [939, 11, 99, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3084776886],
-    [943, 11, 82, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 1524553529],
-    [951, 7, 89, "RSpec/NoExpectationExample: No expectation found in this example.", 4609419],
-    [1039, 11, 99, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3084776886],
-    [1043, 11, 82, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 1524553529],
-    [1123, 17, 12, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 664794325],
-    [1148, 5, 459, "RSpec/NoExpectationExample: No expectation found in this example.", 2216851076],
-    [1158, 7, 450, "RSpec/NoExpectationExample: No expectation found in this example.", 2619808549]
+    [175, 7, 492, "RSpec/NoExpectationExample: No expectation found in this example.", 1272021224],
+    [194, 7, 592, "RSpec/NoExpectationExample: No expectation found in this example.", 3428877205],
+    [207, 15, 20, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 2320605227],
+    [222, 15, 20, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1276531672],
+    [237, 15, 43, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 1383956904],
+    [252, 15, 43, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 3376202107],
+    [830, 5, 360, "RSpec/NoExpectationExample: No expectation found in this example.", 536201463],
+    [839, 5, 461, "RSpec/NoExpectationExample: No expectation found in this example.", 3392600621],
+    [850, 5, 340, "RSpec/NoExpectationExample: No expectation found in this example.", 244592251],
+    [895, 63, 2, "RSpec/BeEq: Prefer `be` over `eq`.", 5860785],
+    [940, 11, 99, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3084776886],
+    [944, 11, 82, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 1524553529],
+    [952, 7, 89, "RSpec/NoExpectationExample: No expectation found in this example.", 4609419],
+    [1040, 11, 99, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 3084776886],
+    [1044, 11, 82, "Style/ClassMethodsDefinitions: Use `class << self` to define a class method.", 1524553529],
+    [1124, 17, 12, "RSpec/ContextWording: Context description should match /^when\\b/, /^with\\b/, or /^without\\b/.", 664794325]
   ],
   "spec/oauth2/error_spec.rb:1209122273": [
     [23, 1, 28, "RSpec/SpecFilePathFormat: Spec path should end with `o_auth2/error*_spec.rb`.", 3385870076],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning v2](https://semver.org/spec/v2.
     - Specify the parameter name that identifies the access token
 - [!645](https://gitlab.com/oauth-xx/oauth2/-/merge_requests/645) - Add `OAuth2::OAUTH_DEBUG` constant, based on `ENV["OAUTH_DEBUG"] (@pboling)
 - [!646](https://gitlab.com/oauth-xx/oauth2/-/merge_requests/646) - Add `OAuth2.config.silence_extra_tokens_warning`, default: false (@pboling)
+- Added IETF RFC 7009 Token Revocation compliant `OAuth2::Client#revoke_token` and `OAuth2::AccessToken#revoke`
+  - See: https://datatracker.ietf.org/doc/html/rfc7009
 ### Changed
 - Default value of `OAuth2.config.silence_extra_tokens_warning` was `false`, now `true`
 - Gem releases are now cryptographically signed, with a 20-year cert (@pboling)

--- a/lib/oauth2.rb
+++ b/lib/oauth2.rb
@@ -32,7 +32,7 @@ module OAuth2
   )
   @config = DEFAULT_CONFIG.dup
   class << self
-    attr_accessor :config
+    attr_reader :config
   end
   def configure
     yield @config

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -164,17 +164,24 @@ You may need to set `snaky: false`. See inline documentation for more info.
       !!@expires_at
     end
 
-    # Whether the token is expired
+    # Check if token is expired
     #
-    # @return [Boolean]
+    # @return [Boolean] true if the token is expired, false otherwise
     def expired?
       expires? && (expires_at <= Time.now.to_i)
     end
 
     # Refreshes the current Access Token
     #
-    # @return [AccessToken] a new AccessToken
-    # @note options should be carried over to the new AccessToken
+    # @param [Hash] params additional params to pass to the refresh token request
+    # @param [Hash] access_token_opts options that will be passed to the AccessToken initialization
+    #
+    # @yield [opts] The block to modify the refresh token request options
+    # @yieldparam [Hash] opts The options hash that can be modified
+    #
+    # @return [OAuth2::AccessToken] a new AccessToken instance
+    #
+    # @note current token's options are carried over to the new AccessToken
     def refresh(params = {}, access_token_opts = {}, &block)
       raise OAuth2::Error.new({error: "A refresh_token is not available"}) unless refresh_token
 
@@ -282,7 +289,16 @@ You may need to set `snaky: false`. See inline documentation for more info.
     # @param [Symbol] verb the HTTP request method
     # @param [String] path the HTTP URL path of the request
     # @param [Hash] opts the options to make the request with
-    #   @see Client#request
+    # @option opts [Hash] :params additional URL parameters
+    # @option opts [Hash, String] :body the request body
+    # @option opts [Hash] :headers request headers
+    #
+    # @yield [req] The block to modify the request
+    # @yieldparam [Faraday::Request] req The request object that can be modified
+    #
+    # @return [OAuth2::Response] the response from the request
+    #
+    # @see OAuth2::Client#request
     def request(verb, path, opts = {}, &block)
       configure_authentication!(opts)
       @client.request(verb, path, opts, &block)

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -34,7 +34,7 @@ module OAuth2
       # @note If no token keys are present, a warning will be issued unless
       #   OAuth2.config.silence_no_tokens_warning is true
       # @note For "soon-to-expire"/"clock-skew" functionality see the `:expires_latency` option.
-      # @mote If snaky key conversion is being used, token_name needs to match the converted key.
+      # @note If snaky key conversion is being used, token_name needs to match the converted key.
       #
       # @example
       #   hash = { 'access_token' => 'token_value', 'refresh_token' => 'refresh_value' }
@@ -125,8 +125,10 @@ You may need to set `snaky: false`. See inline documentation for more info.
       no_tokens = (@token.nil? || @token.empty?) && (@refresh_token.nil? || @refresh_token.empty?)
       if no_tokens
         if @client.options[:raise_errors]
-          error = Error.new(opts)
-          raise(error)
+          raise Error.new({
+            error: "OAuth2::AccessToken has no token",
+            error_description: "Options are: #{opts.inspect}",
+          })
         elsif !OAuth2.config.silence_no_tokens_warning
           warn("OAuth2::AccessToken has no token")
         end
@@ -155,14 +157,14 @@ You may need to set `snaky: false`. See inline documentation for more info.
       @params[key]
     end
 
-    # Whether or not the token expires
+    # Whether the token expires
     #
     # @return [Boolean]
     def expires?
       !!@expires_at
     end
 
-    # Whether or not the token is expired
+    # Whether the token is expired
     #
     # @return [Boolean]
     def expired?
@@ -181,7 +183,7 @@ You may need to set `snaky: false`. See inline documentation for more info.
       new_token = @client.get_token(params, access_token_opts)
       new_token.options = options
       if new_token.refresh_token
-        # Keep it, if there is one
+        # Keep it if there is one
       else
         new_token.refresh_token = refresh_token
       end

--- a/lib/oauth2/access_token.rb
+++ b/lib/oauth2/access_token.rb
@@ -175,12 +175,12 @@ You may need to set `snaky: false`. See inline documentation for more info.
     #
     # @return [AccessToken] a new AccessToken
     # @note options should be carried over to the new AccessToken
-    def refresh(params = {}, access_token_opts = {})
-      raise("A refresh_token is not available") unless refresh_token
+    def refresh(params = {}, access_token_opts = {}, &block)
+      raise OAuth2::Error.new({error: "A refresh_token is not available"}) unless refresh_token
 
       params[:grant_type] = "refresh_token"
       params[:refresh_token] = refresh_token
-      new_token = @client.get_token(params, access_token_opts)
+      new_token = @client.get_token(params, access_token_opts, &block)
       new_token.options = options
       if new_token.refresh_token
         # Keep it if there is one

--- a/lib/oauth2/authenticator.rb
+++ b/lib/oauth2/authenticator.rb
@@ -17,7 +17,7 @@ module OAuth2
 
     # Apply the request credentials used to authenticate to the Authorization Server
     #
-    # Depending on configuration, this might be as request params or as an
+    # Depending on the configuration, this might be as request params or as an
     # Authorization header.
     #
     # User-provided params and header take precedence.

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -43,6 +43,7 @@ module OAuth2
     # @option options [Logger] :logger (::Logger.new($stdout)) Logger instance for HTTP request/response output; requires OAUTH_DEBUG to be true
     # @option options [Class] :access_token_class (AccessToken) class to use for access tokens; you can subclass OAuth2::AccessToken, @version 2.0+
     # @option options [Hash] :ssl SSL options for Faraday
+    #
     # @yield [builder] The Faraday connection builder
     def initialize(client_id, client_secret, options = {}, &block)
       opts = options.dup
@@ -106,6 +107,7 @@ module OAuth2
     # Makes a request relative to the specified site root.
     # Updated HTTP 1.1 specification (IETF RFC 7231) relaxed the original constraint (IETF RFC 2616),
     #   allowing the use of relative URLs in Location headers.
+    #
     # @see https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2
     #
     # @param [Symbol] verb one of :get, :post, :put, :delete
@@ -141,7 +143,7 @@ module OAuth2
           raise(error, "Got #{response.status} status code, but no Location header was present")
         end
       when 200..299, 300..399
-        # on non-redirecting 3xx statuses, just return the response
+        # on non-redirecting 3xx statuses, return the response
         response
       when 400..599
         if opts.fetch(:raise_errors, options[:raise_errors])
@@ -164,6 +166,7 @@ module OAuth2
     #   * params can include a 'snaky' key to control snake_case conversion (default: false)
     # @param [Hash] access_token_opts options that will be passed to the AccessToken initialization
     # @param [Proc] extract_access_token (deprecated) a proc that can extract the access token from the response
+    #
     # @yield [opts] The block is passed the options being used to make the request
     # @yieldparam [Hash] opts options being passed to the http library
     #
@@ -218,7 +221,8 @@ module OAuth2
     end
 
     # The HTTP Method of the request
-    # @return [Symbol] HTTP verb, one of :get, :post, :put, :delete
+    #
+    # @return [Symbol] HTTP verb, one of [:get, :post, :put, :delete]
     def http_method
       http_meth = options[:token_method].to_sym
       return :post if http_meth == :post_with_query_string
@@ -264,7 +268,7 @@ module OAuth2
     # requesting authorization. If it is provided at authorization time it MUST
     # also be provided with the token exchange request.
     #
-    # Providing the :redirect_uri to the OAuth2::Client instantiation will take
+    # Providing :redirect_uri to the OAuth2::Client instantiation will take
     # care of managing this.
     #
     # @api semipublic
@@ -273,6 +277,7 @@ module OAuth2
     # @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3
     # @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.1
     # @see https://datatracker.ietf.org/doc/html/rfc6749#section-10.6
+    #
     # @return [Hash] the params to add to a request or URL
     def redirection_params
       if options[:redirect_uri]
@@ -309,7 +314,7 @@ module OAuth2
       parse = params.key?(:parse) ? params.delete(:parse) : Response::DEFAULT_OPTIONS[:parse]
       snaky = params.key?(:snaky) ? params.delete(:snaky) : Response::DEFAULT_OPTIONS[:snaky]
       params = authenticator.apply(params)
-      # authenticator may add :headers, and we remove them here
+      # authenticator may add :headers, and we separate them from params here
       headers = params.delete(:headers) || {}
       [parse, snaky, params, headers]
     end

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -291,6 +291,15 @@ module OAuth2
       @client_credentials ||= OAuth2::Strategy::ClientCredentials.new(self)
     end
 
+    # The Assertion strategy
+    #
+    # This allows for assertion-based authentication where an identity provider
+    # asserts the identity of the user or client application seeking access.
+    #
+    # @see http://datatracker.ietf.org/doc/html/rfc7521
+    # @see http://datatracker.ietf.org/doc/html/draft-ietf-oauth-assertions-01#section-4.1
+    #
+    # @return [OAuth2::Strategy::Assertion] the initialized Assertion strategy
     def assertion
       @assertion ||= OAuth2::Strategy::Assertion.new(self)
     end

--- a/lib/oauth2/client.rb
+++ b/lib/oauth2/client.rb
@@ -72,13 +72,16 @@ module OAuth2
 
     # Set the site host
     #
-    # @param value [String] the OAuth2 provider site host
+    # @param [String] value the OAuth2 provider site host
+    # @return [String] the site host value
     def site=(value)
       @connection = nil
       @site = value
     end
 
     # The Faraday connection object
+    #
+    # @return [Faraday::Connection] the initialized Faraday connection
     def connection
       @connection ||=
         Faraday.new(site, options[:connection_opts]) do |builder|
@@ -95,6 +98,7 @@ module OAuth2
     # The authorize endpoint URL of the OAuth2 provider
     #
     # @param [Hash] params additional query parameters
+    # @return [String] the constructed authorize URL
     def authorize_url(params = {})
       params = (params || {}).merge(redirection_params)
       connection.build_url(options[:authorize_url], params).to_s
@@ -102,25 +106,28 @@ module OAuth2
 
     # The token endpoint URL of the OAuth2 provider
     #
-    # @param [Hash] params additional query parameters
+    # @param [Hash, nil] params additional query parameters
+    # @return [String] the constructed token URL
     def token_url(params = nil)
       connection.build_url(options[:token_url], params).to_s
     end
 
     # The revoke endpoint URL of the OAuth2 provider
     #
-    # @param [Hash] params additional query parameters
+    # @param [Hash, nil] params additional query parameters
+    # @return [String] the constructed revoke URL
     def revoke_url(params = nil)
       connection.build_url(options[:revoke_url], params).to_s
     end
 
     # Makes a request relative to the specified site root.
+    #
     # Updated HTTP 1.1 specification (IETF RFC 7231) relaxed the original constraint (IETF RFC 2616),
     #   allowing the use of relative URLs in Location headers.
     #
     # @see https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.2
     #
-    # @param [Symbol] verb one of :get, :post, :put, :delete
+    # @param [Symbol] verb one of [:get, :post, :put, :delete]
     # @param [String] url URL path of request
     # @param [Hash] opts the options to make the request with
     # @option req_opts [Hash] :params additional query parameters for the URL of the request
@@ -129,9 +136,13 @@ module OAuth2
     # @option req_opts [Boolean] :raise_errors whether to raise an OAuth2::Error on 400+ status
     #   code response for this request.  Overrides the client instance setting.
     # @option req_opts [Symbol] :parse @see Response::initialize
-    # @option req_opts [true, false] :snaky (true) @see Response::initialize
+    # @option req_opts [Boolean] :snaky (true) @see Response::initialize
     #
-    # @yield [req] @see Faraday::Connection#run_request
+    # @yield [req] The block is passed the request being made, allowing customization
+    # @yieldparam [Faraday::Request] req The request object that can be modified
+    # @see Faraday::Connection#run_request
+    #
+    # @return [OAuth2::Response] the response from the request
     def request(verb, url, req_opts = {}, &block)
       response = execute_request(verb, url, req_opts, &block)
       status = response.status

--- a/spec/oauth2/access_token_spec.rb
+++ b/spec/oauth2/access_token_spec.rb
@@ -389,7 +389,7 @@ RSpec.describe OAuth2::AccessToken do
             let(:token) { "" }
 
             it "raises on initialize" do
-              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: {mode: :this_is_bad, raise_errors: true}"}.to_s)
+              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: #{{mode: :this_is_bad, raise_errors: true}}"}.to_s)
             end
           end
 
@@ -397,7 +397,7 @@ RSpec.describe OAuth2::AccessToken do
             let(:token) { nil }
 
             it "raises on initialize" do
-              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: {mode: :this_is_bad, raise_errors: true}"}.to_s)
+              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: #{{mode: :this_is_bad, raise_errors: true}}"}.to_s)
             end
           end
         end
@@ -603,7 +603,7 @@ RSpec.describe OAuth2::AccessToken do
 
           context "when there is no refresh_token" do
             it "raises on initialize" do
-              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: {raise_errors: true}"}.to_s)
+              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: #{{raise_errors: true}}"}.to_s)
             end
           end
 
@@ -629,7 +629,7 @@ RSpec.describe OAuth2::AccessToken do
 
           context "when there is no refresh_token" do
             it "raises on initialize" do
-              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: {raise_errors: true}"}.to_s)
+              block_is_expected.to raise_error(OAuth2::Error, {error: "OAuth2::AccessToken has no token", error_description: "Options are: #{{raise_errors: true}}"}.to_s)
             end
           end
 


### PR DESCRIPTION
- [x] Added [IETF RFC 7009 Token Revocation](https://datatracker.ietf.org/doc/html/rfc7009)
  - `OAuth2::Client#revoke_token`
  - `OAuth2::AccessToken#revoke`
- [x] `OAuth2::AccessToken#refresh` now supports block param pass through
- [x] `OAuth2.config` is no longer writable
  - the hash it contains still is, of course!
- [x] Errors raised by OAuth2::AccessToken are now always `OAuth2::Error` and have better metadata
- [x] Fixes https://github.com/oauth-xx/oauth2/issues/224, https://gitlab.com/oauth-xx/oauth2/-/issues/224